### PR TITLE
Refactor nullable type environments

### DIFF
--- a/lib/common/type.ml
+++ b/lib/common/type.ml
@@ -282,6 +282,11 @@ let is_mailbox_type = function
     | Mailbox _ -> true
     | _ -> false
 
+let rec contains_mailbox_type = function
+    | Mailbox _ -> true
+    | Sum (t1, t2) | Pair (t1, t2) -> contains_mailbox_type t1 || contains_mailbox_type t2
+    | _ -> false
+
 (* Easy constructors *)
 let int_type = Base Base.Int
 let string_type = Base Base.String

--- a/lib/typecheck/gripers.ml
+++ b/lib/typecheck/gripers.ml
@@ -220,7 +220,7 @@ let branch_linearity var =
 let combine_mailbox_type var =
     let msg =
         Format.asprintf
-            "Linear mailbox variable %a cannot be used in two separate environments. This typically happens when aliasing a mailbox type, or attempting to use a mailbox variable both as a target for a guard and in its continuation."
+            "Linear variable %a which contains a mailbox type cannot be used in two separate environments. This typically happens when aliasing a mailbox type, or attempting to use a mailbox variable both as a target for a guard and in its continuation."
             Ir.Var.pp_name var
     in
     raise (constraint_gen_error ~subsystem:Errors.GenCombine msg)

--- a/lib/typecheck/nullable_env.ml
+++ b/lib/typecheck/nullable_env.ml
@@ -1,0 +1,22 @@
+(* Operations on nullable type environments.
+   A small wrapper over type environments.
+   We only need to support intersection between two nullable environments,
+   and disjoint combination with a defined environment.
+ *)
+type t = Ty_env.t option
+
+let intersect nenv1 nenv2 =
+    match nenv1, nenv2 with
+        | None, None -> None, Constraint_set.empty
+        | Some env, None | None, Some env -> Some env, Constraint_set.empty
+        | Some env1, Some env2 ->
+            let env, constrs = Ty_env.intersect env1 env2 in
+            Some env, constrs
+
+let combine ienv env1 nenv =
+    match nenv with
+        | Some env2 -> Ty_env.combine ienv env1 env2
+        | _ -> env1, Constraint_set.empty
+
+let of_env env = Some env
+let null = None

--- a/lib/typecheck/nullable_env.mli
+++ b/lib/typecheck/nullable_env.mli
@@ -1,0 +1,10 @@
+(* Operations on nullable type environments.
+   A small wrapper over type environments.
+   We only need to support intersection between two nullable environments,
+   and disjoint combination with a defined environment.
+ *)
+type t
+val intersect : t -> t -> (t * Constraint_set.t)
+val combine : Interface_env.t -> Ty_env.t -> t -> (Ty_env.t * Constraint_set.t)
+val of_env : Ty_env.t -> t
+val null : t

--- a/lib/typecheck/ty_env.mli
+++ b/lib/typecheck/ty_env.mli
@@ -7,10 +7,6 @@ type t
 (** Empty type environment *)
 val empty : t
 
-(** No type environment was constructed. Different to empty typing environment,
-     since it will unify with others. Used for fail guards. *)
-val none : t
-
 val bind : Ir.Var.t -> Type.t -> t -> t
 val lookup : Ir.Var.t -> t -> Type.t
 val lookup_opt : Ir.Var.t -> t -> Type.t option
@@ -26,9 +22,6 @@ val combine : Interface_env.t -> t -> t-> t * Constraint_set.t
 
 (** Joins two sequential / concurrent environments *)
 val join : Interface_env.t -> t -> t -> t * Constraint_set.t
-
-(** Iterated join *)
-val join_many : Interface_env.t -> t list -> t * Constraint_set.t
 
 (** Merges two branching environments (e.g., if-then-else, cases) *)
 val intersect : t -> t -> t * Constraint_set.t


### PR DESCRIPTION
We only need guards to produce nullable environments, and these can be eliminated pretty quickly by combining with the subject of the guard.

Therefore this patch refactors type environments such that they are always defined. This ends up eliminating a lot of illegal states and complexity.