### PR TITLE
More flexible inference for pairs with unrestricted

### DIFF
--- a/lib/common/ir.ml
+++ b/lib/common/ir.ml
@@ -84,7 +84,10 @@ and comp =
       }
     | If of { test: value; then_expr: comp; else_expr: comp }
     | LetPair of {
-        binders: ((Binder.t[@name "binder"]) * (Binder.t[@name "binder"]));
+        (* By annotating with inferred pretypes, we can always use a checking rule
+           during inference, irrespective of whether both of the binders are used. *)
+        binders: ( ((Binder.t[@name "binder"]) * (Pretype.t[@name "pretype"]) option) *
+                   ((Binder.t[@name "binder"]) * (Pretype.t[@name "pretype"]) option));
         pair: value;
         cont: comp
     }
@@ -217,7 +220,7 @@ and pp_comp ppf = function
                         pp_value target
                         pp_message message
         end
-    | LetPair { binders = (b1, b2); pair; cont } ->
+    | LetPair { binders = ((b1, _), (b2, _)); pair; cont } ->
         fprintf ppf "let (%a, %a) = @[<v>%a@] in@,%a"
             Binder.pp b1
             Binder.pp b2

--- a/lib/common/type.ml
+++ b/lib/common/type.ml
@@ -295,6 +295,14 @@ let unit_type = Base Base.Unit
 let function_type linear args result =
     Fun { linear; args; result }
 
+let mailbox_send_unit interface quasilinearity =
+    Mailbox {
+        capability = Capability.Out;
+        interface;
+        pattern = Some (Pattern.One);
+        quasilinearity
+    }
+
 let rec pp ppf =
   let open Format in
   let ps = pp_print_string ppf in

--- a/lib/frontend/sugar_to_ir.ml
+++ b/lib/frontend/sugar_to_ir.ml
@@ -130,7 +130,7 @@ and transform_expr :
                         |> bind_var bnd2
                     in
                     Ir.LetPair {
-                        binders = (bnd1, bnd2);
+                        binders = ((bnd1, None), (bnd2, None));
                         pair = v;
                         cont = transform_expr env' cont k })
         | Case {

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -61,6 +61,11 @@ let rec synthesise_val :
                         ty, Ty_env.singleton v ty, Constraint_set.empty
                     | _, PFun _ ->
                         Gripers.synth_mailbox_function v
+                    (* Although we have an interface pretype annotation, it's not possible
+                       to reliably infer a mailbox type (even with a fresh constraint) since
+                       we don't, a priori, know the capability. Even if we record the initial
+                       capability, it may be used at different 'modes' throughout the function,
+                       so any inference would in effect be a guess. *)
                     | _, _ ->
                         Gripers.synth_variable v
             end

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -494,18 +494,31 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
         (* LetPair is similar to Let. Annoyingly we must revert to synthesis of the pair if
            *either* binder is unused in the continuation. This could maybe be ameliorated somewhat
            if we had wildcard patterns. *)
-        | LetPair { binders = (b1, b2); pair; cont = body } ->
+        | LetPair { binders = ((b1, Some pty1), (b2, Some pty2)); pair; cont = body } ->
             (* Check body type and extract types for binders *)
             let body_env, body_constrs = chk body ty in
             (* Either binder might be unused.
                Revert to synthesis if we don't have type info for both. *)
             let b1var = Var.of_binder b1 in
             let b2var = Var.of_binder b2 in
+            (* Pretypes give us a little more type information, in case we can't check directly. *)
+            let inferred_ty_1 = Ty_env.lookup_opt b1var body_env in
+            let inferred_ty_2 = Ty_env.lookup_opt b2var body_env in
+            (* Default type: special case interface types -- only way something can be an MB but
+               not used is if it's a returnable !1 mailbox type*)
+            let default_ty = function
+                | Pretype.PInterface iname ->
+                        Some Type.(mailbox_send_unit iname Quasilinearity.Returnable)
+                | pty -> Pretype.to_type pty
+            in
+            let get_check_ty pty = function
+                | Some ty -> Some ty
+                | None -> default_ty pty
+            in
+            let check_ty_1 = get_check_ty pty1 inferred_ty_1 in
+            let check_ty_2 = get_check_ty pty2 inferred_ty_2 in
             let env, constrs =
-                match
-                    Ty_env.lookup_opt b1var body_env,
-                    Ty_env.lookup_opt b2var body_env
-                with
+                match (check_ty_1, check_ty_2) with
                     | Some b1ty, Some b2ty ->
                         (* Note: make_pair_type ensures both types are returnable *)
                         let target_ty =
@@ -524,7 +537,9 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
                         (env, constrs)
                     | _, _ ->
                         (* In this case, all we can really do is synthesise and
-                           check it's not linear. *)
+                           check it's not linear.
+                           This should only happen for the case where we have a
+                           function returning an MB type.*)
                         let (pair_ty, pair_env, pair_constrs) =
                             synthesise_val ienv decl_env pair
                         in
@@ -561,6 +576,7 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
                 |> Ty_env.delete b2var
             in
             (env, constrs)
+        | LetPair _ -> assert false (* Pretypes should have been filled in *)
         | Guard { iname = None; _ } -> (* Should have been filled in by pre-typing *)
             assert false
         | Guard { target; pattern; guards; iname = Some iname } ->

--- a/lib/typecheck/pretypecheck.ml
+++ b/lib/typecheck/pretypecheck.ml
@@ -226,7 +226,7 @@ and synthesise_comp ienv env comp =
                 |> PretypeEnv.bind (Var.of_binder b2) t2
             in
             let cont, cont_ty = synthesise_comp ienv env' cont in
-            LetPair { binders = ((b1, t1), (b2, t2)); pair; cont }, cont_ty
+            LetPair { binders = ((b1, Some t1), (b2, Some t2)); pair; cont }, cont_ty
         | Seq (e1, e2) ->
             let e1 = check_comp ienv env e1 (Pretype.PBase Unit) in
             let e2, e2_ty = synth e2 in

--- a/lib/typecheck/pretypecheck.ml
+++ b/lib/typecheck/pretypecheck.ml
@@ -210,7 +210,7 @@ and synthesise_comp ienv env comp =
             let e1, e1_ty = synthesise_comp ienv e1_env e1 in
             let e2 = check_comp ienv e2_env e2 e1_ty in
             Case { term; branch1 = ((bnd1, ty1), e1); branch2 = ((bnd2, ty2), e2) }, e1_ty
-        | LetPair { binders = (b1, b2); pair; cont } ->
+        | LetPair { binders = ((b1, _), (b2, _)); pair; cont } ->
             let pair, pair_ty = synthv pair in
             let (t1, t2) =
                 match pair_ty with
@@ -226,7 +226,7 @@ and synthesise_comp ienv env comp =
                 |> PretypeEnv.bind (Var.of_binder b2) t2
             in
             let cont, cont_ty = synthesise_comp ienv env' cont in
-            LetPair { binders = (b1, b2); pair; cont }, cont_ty
+            LetPair { binders = ((b1, t1), (b2, t2)); pair; cont }, cont_ty
         | Seq (e1, e2) ->
             let e1 = check_comp ienv env e1 (Pretype.PBase Unit) in
             let e2, e2_ty = synth e2 in

--- a/test/errors/uaf1.pat
+++ b/test/errors/uaf1.pat
@@ -1,10 +1,9 @@
 interface UAF { Message(Unit) }
 
 def go(x : UAF?) : Unit {
-    guard x : (1 + *Message) {
+    guard x : (*Message) {
         free -> x ! Message(())
         receive Message(z) from y ->
-            x ! Message(());
             go(y)
     }
 }

--- a/test/examples/pair_unr_1.pat
+++ b/test/examples/pair_unr_1.pat
@@ -1,0 +1,4 @@
+def synth_bad(): Unit {
+  let (x, y) = ((), ()) in
+  x
+}

--- a/test/examples/pair_unr_2.pat
+++ b/test/examples/pair_unr_2.pat
@@ -1,0 +1,6 @@
+interface MyMailbox1 { }
+
+def synth_bad2(z: MyMailbox1![R]): Unit {
+  let (x, y) = ((), z) in
+  x
+}


### PR DESCRIPTION
We can use pre-typing information in order to allow more flexible typechecking of pair deconstruction when one or more constituent of the pair is unused in the continuation (fixes #9).

Of course this is all a placeholder until we get a 'proper' constraint-based typing algorithm to replace BBT.