### PR TITLE
Replace 'free' sugar with 'empty' guard and 'free' construct

### DIFF
--- a/lib/common/sugar_ast.ml
+++ b/lib/common/sugar_ast.ml
@@ -30,6 +30,7 @@ type expr =
     | Pair of (expr * expr)
     | LetPair of {
         binders: sugar_binder * sugar_binder;
+        annot: ((Type.t[@name "ty"]) * (Type.t[@name "ty"])) option;
         term: expr;
         cont: expr
     }
@@ -60,8 +61,7 @@ type expr =
         guards: guard list;
         iname: string option
     }
-    (* AKA The Diet Guard. free(e), which later desugars to guard e : 1 { free -> () } *)
-    | SugarFree of expr
+    | Free of expr
     (* fail(e)[A], desugars to (guard e : 0 { fail } : A) *)
     | SugarFail of expr * (Type.t [@name "ty"])
 and constant =
@@ -77,7 +77,8 @@ and guard =
         mailbox_binder: sugar_binder;
         cont: expr
     }
-    | Free of expr
+    | GFree of expr
+    | Empty of (sugar_var * expr)
     (* For now, require annotation since Fail can have any type *)
     (* It would be nice to get rid of this later. *)
     | Fail of (Type.t[@name "ty"])
@@ -102,7 +103,11 @@ let is_receive_guard = function
     | _ -> false
 
 let is_free_guard = function
-    | Free _ -> true
+    | GFree _ -> true
+    | _ -> false
+
+let is_empty_guard = function
+    | Empty _ -> true
     | _ -> false
 
 let is_fail_guard = function
@@ -207,9 +212,16 @@ and pp_expr ppf = function
             pp_expr e2
     | Pair (e1, e2) ->
         fprintf ppf "(%a, %a)" pp_expr e1 pp_expr e2
-    | LetPair { binders = (b1, b2); term; cont } ->
+    | LetPair { binders = (b1, b2); annot = None; term; cont } ->
         fprintf ppf "let (%s, %s) = %a in %a"
             b1 b2
+            pp_expr term
+            pp_expr cont
+    | LetPair { binders = (b1, b2); annot = Some (t1, t2); term; cont } ->
+        fprintf ppf "let (%s, %s) : (%a * %a) = %a in %a"
+            b1 b2
+            Type.pp t1
+            Type.pp t2
             pp_expr term
             pp_expr cont
     | Guard { target; pattern; guards; _ } ->
@@ -218,7 +230,7 @@ and pp_expr ppf = function
             pp_expr target
             Type.Pattern.pp pattern
             (pp_print_newline_list pp_guard) guards
-    | SugarFree e -> fprintf ppf "free(%a)" pp_expr e
+    | Free e -> fprintf ppf "free(%a)" pp_expr e
     | SugarFail (e, ty) -> fprintf ppf "fail(%a)[%a]" pp_expr e Type.pp ty
 and pp_guard ppf = function
     | Receive { tag; payload_binders; mailbox_binder; cont } ->
@@ -227,8 +239,15 @@ and pp_guard ppf = function
             (pp_print_comma_list pp_print_string) payload_binders
             mailbox_binder
             pp_expr cont
-    | Free e ->
+    (* 
+       free -> M
+       can be treated as syntactic sugar for
+       empty(x) -> free(x); M
+    *)
+    | GFree e -> 
         fprintf ppf "free ->@,  @[<v>%a@]" pp_expr e
+    | Empty (x, e) ->
+        fprintf ppf "empty(%s) ->@,  @[<v>%a@]" x pp_expr e
     | Fail ty ->
         fprintf ppf "fail[%a]" Type.pp ty
 

--- a/lib/common/type.ml
+++ b/lib/common/type.ml
@@ -424,7 +424,7 @@ let make_function_type linear args result =
     Fun { linear; args; result }
 
 let make_pair_type ty1 ty2 =
-    Pair (ty1, ty2)
+    Pair (make_returnable ty1, make_returnable ty2)
 
 let make_sum_type ty1 ty2 =
     Sum (make_returnable ty1, make_returnable ty2)

--- a/lib/common/type.ml
+++ b/lib/common/type.ml
@@ -424,7 +424,7 @@ let make_function_type linear args result =
     Fun { linear; args; result }
 
 let make_pair_type ty1 ty2 =
-    Pair (make_returnable ty1, make_returnable ty2)
+    Pair (ty1, ty2)
 
 let make_sum_type ty1 ty2 =
     Sum (make_returnable ty1, make_returnable ty2)

--- a/lib/frontend/desugar_let_annotations.ml
+++ b/lib/frontend/desugar_let_annotations.ml
@@ -15,6 +15,13 @@ let visitor =
                     let body = self#visit_expr env body in
                     let term = Annotate (inner_term, Type.make_returnable annot') in
                     Let { binder; annot = None; term; body }
+                | LetPair { binders; annot = Some (ty1, ty2); term; cont } ->
+                    let cont = self#visit_expr env cont in
+                    let term =
+                        Annotate (term,
+                                  Type.make_returnable (Type.make_pair_type ty1 ty2))
+                    in
+                    LetPair { binders; annot = None; term; cont }
                 | e -> super#visit_expr env e
     end
 

--- a/lib/frontend/desugar_sugared_guards.ml
+++ b/lib/frontend/desugar_sugared_guards.ml
@@ -1,24 +1,24 @@
 (*
-    free(M)    ---> guard e : 1 { free -> () }
     fail(M)[A] ---> guard e : 0 { fail[A] }
  *)
 open Common
-open Common_types
 
 let visitor =
     object(self)
         inherit [_] Sugar_ast.map as super
 
+        method! visit_guard env =
+            let open Sugar_ast in
+            function
+                | GFree e ->
+                    let var = "_gf" in
+                    let e = self#visit_expr env e in
+                    Empty (var, Seq (Free (Var var), e))
+                | g -> super#visit_guard env g
+
         method! visit_expr env =
             let open Sugar_ast in
             function
-                | SugarFree e ->
-                    Guard {
-                        target = self#visit_expr env e;
-                        pattern = Type.Pattern.One;
-                        guards = [Free (Constant Constant.unit)];
-                        iname = None
-                    }
                 | SugarFail (e, ty) ->
                    Annotate (
                        Guard {

--- a/lib/frontend/insert_pattern_variables.ml
+++ b/lib/frontend/insert_pattern_variables.ml
@@ -64,8 +64,8 @@ let visitor =
                 decl_return_type = annotate_type decl.decl_return_type;
                 decl_body = self#visit_expr env decl.decl_body }
 
-
         method! visit_expr env = function
+            | Annotate (e, ty) -> Annotate (self#visit_expr env e, annotate_type ty)
             | Lam { linear; parameters; result_type; body } ->
                 let parameters =
                     List.map (fun (x, y) -> (x, annotate_type y)) parameters in

--- a/lib/frontend/lexer.mll
+++ b/lib/frontend/lexer.mll
@@ -23,6 +23,7 @@ let keywords = [
     "guard", GUARD;
     "receive", RECEIVE;
     "free", FREE;
+    "empty", EMPTY;
     "fail", FAIL;
     "in", IN;
     "linfun", LINFUN;

--- a/lib/frontend/pipeline.ml
+++ b/lib/frontend/pipeline.ml
@@ -2,11 +2,16 @@ open Common
 
 let desugar p =
     p
-    |> Desugar_sugared_guards.desugar
     |> Desugar_let_annotations.desugar
+    |> Desugar_sugared_guards.desugar
     |> Insert_pattern_variables.annotate
 
 let typecheck p ir = 
+    (*
+    Format.printf
+        "=== Intermediate Representation: ===\n%a\n\n"
+        (Ir.pp_program) ir;
+        *)
     let ir, prety_opt = Typecheck.Pretypecheck.check ir in
     let (ty, env, constrs) = Typecheck.Gen_constraints.synthesise_program ir in
     let solution = Typecheck.Solve_constraints.solve_constraints constrs in

--- a/lib/frontend/sugar_to_ir.ml
+++ b/lib/frontend/sugar_to_ir.ml
@@ -114,7 +114,7 @@ and transform_expr :
             transform_subterm env e1 (fun _ v1 ->
             transform_subterm env e2 (fun _ v2 ->
                 Ir.Return (Ir.Pair (v1, v2)) |> k env))
-        | LetPair {binders = (b1, b2); term; cont } ->
+        | LetPair {binders = (b1, b2); term; cont; _ } ->
             (* let x = M in N*)
             (* Create an IR variable based on x *)
             let bnd1 = Ir.Binder.make ~name:b1 () in
@@ -163,6 +163,8 @@ and transform_expr :
                     else_expr = transform_expr env else_expr id } |> k env)
         | New i -> Ir.New i |> k env
         | Spawn e -> Ir.Spawn (transform_expr env e id) |> k env
+        | Free e ->
+            transform_subterm env e (fun _ v -> Ir.Free (v, None)) |> k env
         | Send {target; message; iname} ->
             let (tag, payloads) = message in
             transform_subterm env target (fun env pid ->
@@ -180,7 +182,7 @@ and transform_expr :
                     guards = gs;
                     iname
                 } |> k env )
-        | SugarFree _ | SugarFail (_, _) -> (* shouldn't ever match *)
+        |  SugarFail (_, _) -> (* shouldn't ever match *)
                 raise (Errors.internal_error "sugar_to_ir.ml" "Encountered SugarFree/SugarFail expression during the IR translation stage")
 
 (* Transforms a subterm into an IR computation, naming if necessary. *)
@@ -221,9 +223,17 @@ and transform_subterm
                 let bnd = Ir.Binder.make () in
                 (* Create a new variable from the binder *)
                 let var = Ir.Variable ((Ir.Var.of_binder bnd), None) in
+                (* If we are translating an annotation, we need to create a value annotation
+                   in the IR such that we do not lose the type information and needlessly resort
+                   to synthesis *)
+                let var' =
+                    match x with
+                        | Annotate (_, ty) -> Ir.VAnnotate (var, ty)
+                        | _ -> var
+                in
                 (* Return a 'let' expression with the binder, binding the computation,
                    and apply the continuation to the bound variable *)
-                Ir.Let { binder = bnd; term = c; cont = (k env var) })
+                Ir.Let { binder = bnd; term = c; cont = (k env var') })
 
 and transform_guard :
     env ->
@@ -239,7 +249,11 @@ and transform_guard :
             mailbox_binder = mailbox_bnd;
             cont
         }
-    | Free e -> Ir.Free (transform_expr env e id)
+    | Empty (bnd, cont) ->
+        let (mailbox_bnd, env) = add_name env bnd in
+        let cont = transform_expr env cont id in
+        Ir.Empty (mailbox_bnd, cont)
+    | GFree _ -> raise (Errors.internal_error "sugar_to_ir.ml" "Encountered Free guard during the IR translation stage")
     (* type will have been expanded into an annotation by this point *)
     | Fail _ -> Ir.Fail
 

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -191,8 +191,8 @@ and check_val :
                 end
             in
             (* We can only construct a pair if its components are returnable. *)
-            let (env1, constrs1) = check_val ienv decl_env v1 t1 in
-            let (env2, constrs2) = check_val ienv decl_env v2 t2 in
+            let (env1, constrs1) = check_val ienv decl_env v1 (Type.make_returnable t1) in
+            let (env2, constrs2) = check_val ienv decl_env v2 (Type.make_returnable t2) in
             let env, constrs3 = Ty_env.combine ienv env1 env2 in
             env, Constraint_set.union_many [constrs1; constrs2; constrs3]
         | _ ->
@@ -322,7 +322,7 @@ and synthesise_comp :
                 match Ty_env.lookup_opt (Var.of_binder binder) body_env with
                     | Some binder_ty ->
                         let (term_env, term_constrs) =
-                            check_comp ienv decl_env term (Type.make_usable binder_ty)
+                            check_comp ienv decl_env term (Type.make_returnable binder_ty)
                         in
                         (* Join environments, union constraints *)
                         let (env, env_constrs) =
@@ -918,7 +918,7 @@ let synthesise_program { prog_interfaces; prog_decls; prog_body } =
     match prog_body with
         | Some body ->
             let ty, body_env, body_constrs = synthesise_comp ienv decl_env body in
-            let env, env_constrs = Ty_env.join ienv decl_env body_env in
+            let env, env_constrs = Ty_env.combine ienv decl_env body_env in
             let constrs =
                 Constraint_set.union_many
                     [decl_constrs; body_constrs; env_constrs]
@@ -937,7 +937,7 @@ let check_program { prog_interfaces; prog_decls; prog_body } ty =
     match prog_body with
         | Some body ->
             let body_env, body_constrs = check_comp ienv decl_env body ty in
-            let env, env_constrs = Ty_env.join ienv decl_env body_env in
+            let env, env_constrs = Ty_env.combine ienv decl_env body_env in
             let constrs =
                 Constraint_set.union_many
                     [decl_constrs; body_constrs; env_constrs]

--- a/lib/typecheck/gripers.ml
+++ b/lib/typecheck/gripers.ml
@@ -87,10 +87,10 @@ let unused_synthesised_linear_var v ty =
     in
     raise (constraint_gen_error ~subsystem:(Errors.GenCheck) msg)
 
-let multiple_free () =
+let multiple_empty () =
     raise (constraint_gen_error
         ~subsystem:(Errors.GenCheckGuard)
-        "At most one `free` guard allowed.")
+        "At most one `empty` guard allowed.")
 
 let multiple_fail () =
     raise (constraint_gen_error

--- a/lib/typecheck/type_utils.ml
+++ b/lib/typecheck/type_utils.ml
@@ -65,21 +65,23 @@ let rec subtype_type :
                 capability = capability1;
                 interface = iname1;
                 pattern = Some pat1;
-                quasilinearity = ql1
+                quasilinearity = _ql1
               },
               Mailbox {
                 capability = capability2;
                 interface = iname2;
                 pattern = Some pat2;
-                quasilinearity = ql2
+                quasilinearity = _ql2
               } ->
                   (* First, ensure interface subtyping *)
                   let interface1 = Interface_env.lookup iname1 ienv in
                   let interface2 = Interface_env.lookup iname2 ienv in
+                  (*
                   let () =
                       if not (Type.Quasilinearity.is_sub ql1 ql2) then
                           Gripers.quasilinearity_mismatch t1 t2
                   in
+                  *)
                   let iface_constraints =
                       subtype_interface visited ienv interface1 interface2 in
                   let pat_constraints =

--- a/test/examples/de_liguoro_padovani/future_state_passing.pat
+++ b/test/examples/de_liguoro_padovani/future_state_passing.pat
@@ -1,0 +1,38 @@
+interface Future { Put(Int), Get(User!) }
+interface User   { Reply(Int) }
+
+def future(self: Future?): (Unit * Future?1) {
+    guard self : Put.(*Get) {
+        receive Put(x) from self -> resolvedFuture(self, x)
+    }
+}
+
+def resolvedFuture(self: Future?, value: Int): (Unit * Future?1) {
+    guard self : *Get {
+        empty(x) -> ((), x)
+        receive Get(user) from self ->
+            user ! Reply(value);
+            resolvedFuture(self, value)
+    }
+}
+
+def user(future: Future!): Int {
+    let self = new[User] in
+    future ! Get(self);
+    guard self : Reply {
+        receive Reply(x) from self ->
+            free(self);
+            x
+    }
+}
+
+def main(): Unit {
+    # Test comment
+    let future_mb = new[Future] in
+    spawn { let (x, mb) : (Unit * Future?1) = future(future_mb) in free(mb) };
+    future_mb ! Put(5);
+    print(intToString(user(future_mb)));
+    print(intToString(user(future_mb)))
+}
+
+main()


### PR DESCRIPTION
Before, we were using the syntactic sugar:

[[ free V ]] = guard V : 1 { free -> () }

For Mailboxer we actually need a slightly more general solution:

  * Replace the 'free' guard with an 'empty(x) -> M' guard, which is triggered in the same scenarios as 'free' but does not deallocate the variable. Instead the mailbox is bound to 'x' with type ?1.
  * Delete the `free V` sugar
  * Introduce a native `free V : ?1 -> Unit` construct that explicitly deallocates a mailbox of type `?1`

Everything typable before is typable now.