### PR TITLE
Generalise pairs to n-tuples

### DIFF
--- a/lib/common/common_types.ml
+++ b/lib/common/common_types.ml
@@ -6,14 +6,12 @@ module Base = struct
         | Int
         | Bool
         | String
-        | Unit
     [@@deriving show]
 
     let pp ppf =
         let ps = Format.pp_print_string ppf in
         function
            | Atom -> ps "Atom"
-           | Unit -> ps "Unit"
            | Int -> ps "Int"
            | Bool -> ps "Bool"
            | String -> ps "String"
@@ -30,24 +28,20 @@ type tag = string
 (* Boxed constants *)
 module Constant = struct
     type t =
-        | Unit
         | Int of int
         | String of string
         | Bool of bool
 
     let type_of = function
-        | Unit -> Base.Unit
         | Int _ -> Base.Int
         | Bool _ -> Base.Bool
         | String _ -> Base.String
 
     let pp ppf = function
-        | Unit -> Format.pp_print_string ppf "()"
         | Int i -> Format.pp_print_int ppf i
         | String s -> Format.fprintf ppf "\"%s\"" s
         | Bool b -> Format.pp_print_bool ppf b
 
-    let unit = Unit
     let wrap_int i = Int i
     let wrap_string s = String s
     let wrap_bool b = Bool b

--- a/lib/common/ir.ml
+++ b/lib/common/ir.ml
@@ -283,6 +283,7 @@ and pp_guard ppf guard_with_pos =
     | Fail ->
         fprintf ppf "fail"
 
+let unit = Tuple []
 
 let is_receive_guard = function
     | Receive _ -> true

--- a/lib/common/lib_types.ml
+++ b/lib/common/lib_types.ml
@@ -20,9 +20,9 @@ let signatures =
     in
     int_ops @ int_rel_ops @ bool_rel_ops @
     [
-        ("print", function_type false [Base Base.String] (Base Base.Unit));
-        ("concat", function_type false [Base Base.String; Base Base.String] (Base Base.String));
+        ("print", function_type false [Base Base.String] Type.unit_type);
+        ("concat", function_type false [Base Base.String; Base Base.String] Type.string_type);
         ("rand", function_type false [Base Base.Int] (Base Base.Int));
-        ("sleep", function_type false [Base Base.Int] (Base Base.Unit));
+        ("sleep", function_type false [Base Base.Int] Type.unit_type);
         ("intToString", function_type false [Base Base.Int] (Base Base.String))
     ]

--- a/lib/common/pretype.ml
+++ b/lib/common/pretype.ml
@@ -19,6 +19,8 @@ type t =
     [@@deriving visitors { variety = "map" }]
 and base = [%import: Common_types.Base.t]
 
+let unit = PTuple []
+
 let rec pp ppf =
   let open Format in
   let ps = pp_print_string ppf in

--- a/lib/common/pretype.ml
+++ b/lib/common/pretype.ml
@@ -14,27 +14,28 @@ type t =
     | PFun of { linear: bool; args: (Type.t[@name "ty"]) list; result: t[@name "pretype"] }
     | PInterface of string
     | PSum of (t * t)
-    | PPair of (t * t)
+    | PTuple of t list
     [@@name "pretype"]
     [@@deriving visitors { variety = "map" }]
 and base = [%import: Common_types.Base.t]
 
 let rec pp ppf =
-  let ps = Format.pp_print_string ppf in
+  let open Format in
+  let ps = pp_print_string ppf in
   function
     | PBase b -> Common_types.Base.pp ppf b
     | PFun { linear; args; result } ->
         let arrow = if linear then "-o" else "->" in
-        Format.fprintf ppf "(%a) %s %a"
+        fprintf ppf "(%a) %s %a"
             (pp_print_comma_list Type.pp) args
             arrow
             pp result
-    | PPair (t1, t2) ->
-        Format.fprintf ppf "(%a * %a)"
-            pp t1
-            pp t2
+    | PTuple ts ->
+        let pp_star ppf () = pp_print_string ppf " * " in
+        fprintf ppf "(%a)"
+            (pp_print_list ~pp_sep:(pp_star) pp) ts
     | PSum (t1, t2) ->
-        Format.fprintf ppf "(%a + %a)"
+        fprintf ppf "(%a + %a)"
             pp t1
             pp t2
     | PInterface name -> ps name
@@ -48,7 +49,7 @@ let rec of_type = function
     | Type.Base b -> PBase b
     | Type.Fun { linear; args; result } ->
         PFun { linear; args; result = of_type result }
-    | Type.Pair (t1, t2) -> PPair (of_type t1, of_type t2)
+    | Type.Tuple ts -> PTuple (List.map of_type ts)
     | Type.Sum (t1, t2) -> PSum (of_type t1, of_type t2)
     | Type.Mailbox { interface; _ } -> PInterface interface
 
@@ -63,16 +64,18 @@ let rec to_type = function
         (fun result ->
             Some (Type.Fun { linear; args; result })
         )
-    | PPair (t1, t2) ->
-        begin
-        match to_type t1, to_type t2 with
-            | Some ty1, Some ty2 -> Some (Type.Pair (ty1, ty2))
-            | _, _ -> None
-        end
+    | PTuple ts ->
+        let rec go acc =
+            function
+                | [] -> Some (List.rev acc)
+                | x :: xs ->
+                    Option.bind (to_type x) (fun t -> go (t :: acc) xs)
+        in
+        Option.bind (go [] ts) (fun ts -> Some (Type.Tuple ts))
     | PSum (t1, t2) ->
         begin
-        match to_type t1, to_type t2 with
-            | Some ty1, Some ty2 -> Some (Type.Sum (ty1, ty2))
-            | _, _ -> None
+            match to_type t1, to_type t2 with
+                | Some ty1, Some ty2 -> Some (Type.Sum (ty1, ty2))
+                | _, _ -> None
         end
     | PInterface _ -> None

--- a/lib/common/sugar_ast.ml
+++ b/lib/common/sugar_ast.ml
@@ -31,11 +31,11 @@ and expr_node =
         args: expr list
     }
     | If of { test: expr; then_expr: expr; else_expr: expr }
-    (* Pairs *)
-    | Pair of (expr * expr)
-    | LetPair of {
-        binders: sugar_binder * sugar_binder;
-        annot: ((Type.t[@name "ty"]) * (Type.t[@name "ty"])) option;
+    (* Tuples *)
+    | Tuple of expr list
+    | LetTuple of {
+        binders: sugar_binder list;
+        annot: ((Type.t[@name "ty"]) list) option;
         term: expr;
         cont: expr
     }
@@ -224,18 +224,18 @@ and pp_expr ppf expr_with_pos =
             pp_expr e1
             pp_bnd_ann bnd2
             pp_expr e2
-    | Pair (e1, e2) ->
-        fprintf ppf "(%a, %a)" pp_expr e1 pp_expr e2
-    | LetPair { binders = (b1, b2); annot = None; term; cont } ->
-        fprintf ppf "let (%s, %s) = %a in %a"
-            b1 b2
+    | Tuple es ->
+        fprintf ppf "(%a)" (pp_print_comma_list pp_expr) es
+    | LetTuple { binders = bs; annot = None; term; cont } ->
+        fprintf ppf "let (%a) = %a in %a"
+            (pp_print_comma_list pp_print_string) bs
             pp_expr term
             pp_expr cont
-    | LetPair { binders = (b1, b2); annot = Some (t1, t2); term; cont } ->
-        fprintf ppf "let (%s, %s) : (%a * %a) = %a in %a"
-            b1 b2
-            Type.pp t1
-            Type.pp t2
+    | LetTuple { binders = bs; annot = Some ts; term; cont } ->
+        assert (List.length bs = List.length ts);
+        fprintf ppf "let (%a) : (%a) = %a in %a"
+            (pp_print_comma_list pp_print_string) bs
+            (pp_print_comma_list Type.pp) ts
             pp_expr term
             pp_expr cont
     | Guard { target; pattern; guards; _ } ->

--- a/lib/common/type.ml
+++ b/lib/common/type.ml
@@ -294,7 +294,7 @@ let rec contains_mailbox_type = function
 let int_type = Base Base.Int
 let string_type = Base Base.String
 let bool_type = Base Base.Bool
-let unit_type = Base Base.Unit
+let unit_type = Tuple []
 let atom = Base Base.Atom
 let function_type linear args result =
     Fun { linear; args; result }

--- a/lib/common/type.ml
+++ b/lib/common/type.ml
@@ -251,7 +251,7 @@ end
 type t =
     | Base of base
     | Fun of { linear: bool; args: t list; result: t }
-    | Pair of (t * t)
+    | Tuple of t list
     | Sum of (t * t)
     | Mailbox of {
         capability: (Capability.t [@name "capability"]);
@@ -286,7 +286,8 @@ let is_mailbox_type = function
 
 let rec contains_mailbox_type = function
     | Mailbox _ -> true
-    | Sum (t1, t2) | Pair (t1, t2) -> contains_mailbox_type t1 || contains_mailbox_type t2
+    | Sum (t1, t2) -> contains_mailbox_type t1 || contains_mailbox_type t2
+    | Tuple ts -> List.exists contains_mailbox_type ts
     | _ -> false
 
 (* Easy constructors *)
@@ -316,10 +317,10 @@ let rec pp ppf =
             (pp_print_comma_list pp) args
             arrow
             pp result
-    | Pair (t1, t2) ->
-        fprintf ppf "(%a * %a)"
-            pp t1
-            pp t2
+    | Tuple ts ->
+        let pp_star ppf () = pp_print_string ppf " * " in
+        fprintf ppf "(%a)"
+            (pp_print_list ~pp_sep:(pp_star) pp) ts
     | Sum (t1, t2) ->
         fprintf ppf "(%a + %a)"
             pp t1
@@ -355,7 +356,7 @@ let rec is_lin = function
     | Fun { linear; _ } -> linear
     (* !1 is unrestricted... *)
     | Mailbox { capability = Out; pattern = Some One; _ } -> false
-    | Pair (t1, t2) -> is_lin t1 || is_lin t2
+    | Tuple ts -> List.exists is_lin ts
     | Sum (t1, t2) -> is_lin t1 || is_lin t2
     (* ...but otherwise a mailbox type must be used linearly. *)
     | Mailbox _ -> true
@@ -368,8 +369,8 @@ let is_output_mailbox = function
     | Mailbox { capability = Out; pattern = Some _; _ } -> true
     | _ -> false
 
-let is_pair = function
-    | Pair _ -> true
+let is_tuple = function
+    | Tuple _ -> true
     | _ -> false
 
 let is_sum = function
@@ -391,13 +392,13 @@ let get_quasilinearity = function
 
 let rec make_usable = function
     | Mailbox m -> Mailbox { m with quasilinearity = Quasilinearity.Usable }
-    | Pair (t1, t2) -> Pair (make_usable t1, make_usable t2)
+    | Tuple ts -> Tuple (List.map make_usable ts)
     | Sum (t1, t2) -> Sum (make_usable t1, make_usable t2)
     | t -> t
 
 let rec make_returnable = function
     | Mailbox m -> Mailbox { m with quasilinearity = Quasilinearity.Returnable }
-    | Pair (t1, t2) -> Pair (make_returnable t1, make_returnable t2)
+    | Tuple ts -> Tuple (List.map make_returnable ts) 
     | Sum (t1, t2) -> Sum (make_returnable t1, make_returnable t2)
     | t -> t
 
@@ -406,15 +407,15 @@ let is_unr = is_lin >> not
 let rec is_returnable = function
     | Mailbox { quasilinearity = ql; _ } ->
         ql = Quasilinearity.Returnable
-    | Pair (t1, t2)
+    | Tuple ts -> List.for_all is_returnable ts
     | Sum  (t1, t2) -> is_returnable t1 && is_returnable t2
     | _ -> true
 
 let make_function_type linear args result =
     Fun { linear; args; result }
 
-let make_pair_type ty1 ty2 =
-    Pair (make_returnable ty1, make_returnable ty2)
+let make_tuple_type tys =
+    Tuple (List.map make_returnable tys)
 
 let make_sum_type ty1 ty2 =
     Sum (make_returnable ty1, make_returnable ty2)

--- a/lib/frontend/desugar_let_annotations.ml
+++ b/lib/frontend/desugar_let_annotations.ml
@@ -17,13 +17,13 @@ let visitor =
                     let body = self#visit_expr env body in
                     let term = { expr_with_pos with node = Annotate (inner_term, Type.make_returnable annot') } in
                         { expr_with_pos with node = Let { binder; annot = None; term; body } }
-                | LetPair { binders; annot = Some (ty1, ty2); term; cont } ->
+                | LetTuple { binders; annot = Some tys; term; cont } ->
                     let cont = self#visit_expr env cont in
                     let term =
                         { expr_with_pos with node = 
-                            Annotate (term, Type.make_returnable (Type.make_pair_type ty1 ty2)) }
+                            Annotate (term, Type.make_returnable (Type.make_tuple_type tys)) }
                     in
-                        { expr_with_pos with node = LetPair { binders; annot = None; term; cont } }
+                        { expr_with_pos with node = LetTuple { binders; annot = None; term; cont } }
                 | _ -> super#visit_expr env expr_with_pos
     end
 

--- a/lib/frontend/insert_pattern_variables.ml
+++ b/lib/frontend/insert_pattern_variables.ml
@@ -18,8 +18,8 @@ let rec annotate_type =
                 args = List.map annotate_type args;
                 result = annotate_type result
             }
-        | Pair (t1, t2) ->
-            Pair (annotate_type t1, annotate_type t2)
+        | Tuple ts ->
+            Tuple (List.map annotate_type ts)
         | Sum (t1, t2) ->
             Sum (annotate_type t1, annotate_type t2)
         | Mailbox { pattern = Some _; _ } as mb -> mb

--- a/lib/frontend/parser.mly
+++ b/lib/frontend/parser.mly
@@ -210,7 +210,7 @@ op:
 
 fact:
     (* Unit *)
-    | LEFT_PAREN RIGHT_PAREN { Constant Constant.unit }
+    | LEFT_PAREN RIGHT_PAREN { Tuple [] }
     | ATOM { Atom (String.(sub $1 1 (length $1 - 1))) }
     | BOOL   { Constant (Constant.wrap_bool $1) }
     (* Var *)
@@ -315,17 +315,17 @@ mailbox_ty:
 
 simple_ty:
     | mailbox_ty { $1 }
-    | base_ty { Type.Base $1 }
+    | base_ty { $1 }
 
 base_ty:
     | CONSTRUCTOR {
         match $1 with
-            | "Atom" -> Base.Atom
-            | "Unit" -> Base.Unit
-            | "Int" -> Base.Int
-            | "Bool" -> Base.Bool
-            | "String" -> Base.String
-            | _ -> raise (parse_error "Expected Atom, Unit, Int, Bool, or String"
+            | "Atom" -> Type.Base Base.Atom
+            | "Unit" -> Type.Tuple []
+            | "Int" -> Type.Base Base.Int
+            | "Bool" -> Type.Base Base.Bool
+            | "String" -> Type.Base Base.String
+            | _ -> raise (parse_error "Expected Atom, Int, Bool, or String"
                             [Position.make ~start:$startpos ~finish:$endpos ~code:!source_code_instance])
     }
 

--- a/lib/frontend/sugar_to_ir.ml
+++ b/lib/frontend/sugar_to_ir.ml
@@ -1,5 +1,4 @@
 open Common
-open Common_types
 open Util.Utility
 open Source_code
 
@@ -173,7 +172,7 @@ and transform_expr :
             transform_expr env e1 (fun env c1 ->
             let pos' = WithPos.pos c1 in
             match WithPos.node c1 with
-                | Ir.Return ({ node = Ir.Constant (Constant.Unit); _ }) ->
+                | Ir.Return ({ node = Ir.Tuple []; _ }) ->
                     transform_expr env e2 k
                 | _ -> WithPos.make ~pos:pos' (Ir.Seq (c1, transform_expr env e2 k)))
         | App {func; args} ->

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -63,6 +63,10 @@ let rec synthesise_val :
                     | _, PFun { linear; args; result = PBase b } ->
                         let ty = Type.function_type linear args (Type.Base b) in
                         ty, Ty_env.singleton v ty, Constraint_set.empty
+                    (* Units *)
+                    | _, PFun { linear; args; result = PTuple [] } ->
+                            let ty = Type.function_type linear args (Type.Tuple []) in
+                        ty, Ty_env.singleton v ty, Constraint_set.empty
                     | _, PFun _ ->
                         Gripers.synth_mailbox_function v [pos]
                     (* Although we have an interface pretype annotation, it's not possible

--- a/lib/typecheck/gripers.ml
+++ b/lib/typecheck/gripers.ml
@@ -258,10 +258,10 @@ let expected_function func instead pos_list =
     in
     raise (constraint_gen_error ~subsystem:Errors.GenSynth msg pos_list )
 
-let expected_pair_type instead pos_list =
+let expected_tuple_type instead pos_list =
     let msg =
         Format.asprintf
-            "Expected a pair type, but got %a."
+            "Expected a tuple type, but got %a."
             Type.pp instead
     in
     raise (constraint_gen_error ~subsystem:Errors.GenCheck msg pos_list)

--- a/lib/typecheck/pretypecheck.ml
+++ b/lib/typecheck/pretypecheck.ml
@@ -192,9 +192,9 @@ and synthesise_comp ienv env comp =
             WithPos.make ~pos (New iname), Pretype.PInterface iname
         | Spawn e ->
             let e =
-                check_comp ienv env e (Pretype.PBase Unit)
+                check_comp ienv env e (Pretype.unit)
             in
-            WithPos.make ~pos (Spawn e), Pretype.PBase Unit
+            WithPos.make ~pos (Spawn e), Pretype.unit
         | If { test; then_expr; else_expr } ->
             let test =
                 check_val ienv env test (Pretype.PBase Bool)
@@ -249,7 +249,7 @@ and synthesise_comp ienv env comp =
             WithPos.make ~pos
                 (LetTuple { binders; tuple; cont }), cont_ty
         | Seq (e1, e2) ->
-            let e1 = check_comp ienv env e1 (Pretype.PBase Unit) in
+            let e1 = check_comp ienv env e1 (Pretype.unit) in
             let e2, e2_ty = synth e2 in
             WithPos.make ~pos(Seq (e1, e2)), e2_ty
         | App { func; args } ->
@@ -314,7 +314,7 @@ and synthesise_comp ienv env comp =
                             target;
                             message = (tag, vals);
                             iname = Some iname
-                         }), Pretype.PBase Unit
+                         }), Pretype.unit
                     | ty -> Gripers.type_mismatch_with_expected pos "an interface type" ty
             end
         | Free (v, _) ->
@@ -324,7 +324,7 @@ and synthesise_comp ienv env comp =
                     | PInterface iface -> iface
                     | t -> Gripers.type_mismatch_with_expected pos "an interface type" t
             in
-            WithPos.make ~pos(Free (v, Some iface)), Pretype.PBase Unit
+            WithPos.make ~pos(Free (v, Some iface)), Pretype.unit
         | Guard { target; pattern; guards; _ } ->
             let (target, target_ty) = synthv target in
             let iname =

--- a/lib/typecheck/pretypecheck.ml
+++ b/lib/typecheck/pretypecheck.ml
@@ -21,6 +21,14 @@ module Gripers = struct
         in
         raise (pretype_error msg [pos])
 
+    let tuple_arity_error pos expected_len actual_len =
+        let msg =
+            asprintf "Arity error. Tuple deconstructor has %d binders, but tuple has %d components."
+                expected_len 
+                actual_len
+        in
+        raise (pretype_error msg [pos])
+
     let message_arity_error pos tag expected_len actual_len =
         let msg =
             asprintf "Arity error. Message '%s' expects %d arguments, but %d were provided."
@@ -221,6 +229,13 @@ and synthesise_comp ienv env comp =
                         raise
                             (Gripers.type_mismatch_with_expected pos
                              "a tuple type" tuple_ty)
+            in
+            (* Check arity before we start combining *)
+            let () =
+                let bnds_len = List.length bnds in
+                let tys_len = List.length tys in
+                if bnds_len <> tys_len then
+                    Gripers.tuple_arity_error pos bnds_len tys_len
             in
             let vars_and_tys = List.combine (List.map Var.of_binder bnds) tys in
             let env' =

--- a/lib/typecheck/ty_env.ml
+++ b/lib/typecheck/ty_env.ml
@@ -16,6 +16,10 @@ let lookup = VarMap.find
 let lookup_opt = VarMap.find_opt
 
 let delete = VarMap.remove
+
+let delete_many vars env =
+    List.fold_right (delete) env vars
+
 let delete_binder x = VarMap.remove (Ir.Var.of_binder x)
 let singleton = VarMap.singleton
 let bindings = VarMap.bindings

--- a/lib/typecheck/ty_env.ml
+++ b/lib/typecheck/ty_env.ml
@@ -18,7 +18,7 @@ let lookup_opt = VarMap.find_opt
 let delete = VarMap.remove
 
 let delete_many vars env =
-    List.fold_right (delete) env vars
+    List.fold_right (delete) vars env 
 
 let delete_binder x = VarMap.remove (Ir.Var.of_binder x)
 let singleton = VarMap.singleton
@@ -168,7 +168,9 @@ let combine : Interface_env.t -> t -> t -> Position.t -> t * Constraint_set.t =
 
 
 let combine_many ienv envs pos =
-    List.fold_right (fun x acc -> combine ienv x acc pos) empty envs
+    List.fold_right (fun x (env_acc, constrs_acc) ->
+        let (env, constrs) = combine ienv x env_acc pos in
+        env, Constraint_set.union constrs constrs_acc) envs (empty, Constraint_set.empty)
 
 (* Merges environments resulting from branching control flow. *)
 (* Core idea is that linear types must be used in precisely the same way in

--- a/lib/typecheck/ty_env.ml
+++ b/lib/typecheck/ty_env.ml
@@ -162,6 +162,10 @@ let combine : Interface_env.t -> t -> t -> Position.t -> t * Constraint_set.t =
         in
         fn ienv env1 env2 pos
 
+
+let combine_many ienv envs pos =
+    List.fold_right (fun x acc -> combine ienv x acc pos) empty envs
+
 (* Merges environments resulting from branching control flow. *)
 (* Core idea is that linear types must be used in precisely the same way in
     each branch. Unrestricted types must be used at the same type, but need

--- a/lib/typecheck/ty_env.mli
+++ b/lib/typecheck/ty_env.mli
@@ -11,6 +11,7 @@ val bind : Ir.Var.t -> Type.t -> t -> t
 val lookup : Ir.Var.t -> t -> Type.t
 val lookup_opt : Ir.Var.t -> t -> Type.t option
 val delete : Ir.Var.t -> t -> t
+val delete_many : Ir.Var.t list -> t -> t
 val delete_binder : Ir.Binder.t -> t -> t
 val singleton : Ir.Var.t -> Type.t -> t
 val bindings : t -> (Ir.Var.t * Type.t) list
@@ -19,6 +20,9 @@ val iter : (Ir.Var.t -> Type.t -> unit) -> t -> unit
 
 (** Disjoint connection of environments (i.e., the + operator on environments) *)
 val combine : Interface_env.t -> t -> t -> Position.t -> t * Constraint_set.t
+
+(** Disjoint connection of many environments *)
+val combine_many : Interface_env.t -> t list -> Position.t -> t * Constraint_set.t
 
 (** Joins two sequential / concurrent environments *)
 val join : Interface_env.t -> t -> t -> Position.t -> t * Constraint_set.t

--- a/lib/typecheck/type_utils.ml
+++ b/lib/typecheck/type_utils.ml
@@ -13,6 +13,7 @@ let make_unrestricted t pos =
     match t with
         (* Trivially unrestricted *)
         | Base _
+        | Tuple []
         | Fun { linear = false; _ } -> Constraint_set.empty
         (* Must be unrestricted *)
         | Fun { linear = true; _ }

--- a/lib/typecheck/type_utils.ml
+++ b/lib/typecheck/type_utils.ml
@@ -38,8 +38,11 @@ let rec subtype_type :
             | Base b1, Base b2 when b1 = b2->
                         Constraint_set.empty
 
-            (* Subtyping covariant for pairs and sums *)
-            | Pair (tya1, tya2), Pair (tyb1, tyb2)
+            (* Subtyping covariant for tuples and sums *)
+            | Tuple tyas, Tuple tybs ->
+                Constraint_set.union_many
+                    (List.map (fun (tya, tyb) -> subtype_type visited ienv tya tyb pos) 
+                        (List.combine tyas tybs))
             | Sum (tya1, tya2), Sum (tyb1, tyb2) ->
                 Constraint_set.union
                     (subtype_type visited ienv tya1 tyb1 pos)

--- a/lib/util/utility.ml
+++ b/lib/util/utility.ml
@@ -84,8 +84,8 @@ let print_debug err =
 
 
 (* f: a, b -> c ==> f: (a, b) -> c *)
-let curry f (a, b) = f a b
-let uncurry f a b = f (a, b)
+let curry f a b = f (a, b)
+let uncurry f (a, b) = f a b
 
 let rec split3 = function
     | [] -> ([], [], [])

--- a/lib/util/utility.ml
+++ b/lib/util/utility.ml
@@ -87,8 +87,8 @@ let print_debug err =
 let curry f (a, b) = f a b
 let uncurry f a b = f (a, b)
 
-let split3 = function
+let rec split3 = function
     | [] -> ([], [], [])
     | (x, y, z) :: rest ->
-        let (xs, ys, zs) = go rest in
+        let (xs, ys, zs) = split3 rest in
         (x :: xs, y :: ys, z :: zs)

--- a/lib/util/utility.ml
+++ b/lib/util/utility.ml
@@ -82,3 +82,13 @@ let print_error ?(note="ERROR") err =
 let print_debug err =
     Format.fprintf std_formatter "[\027[34mDEBUG\027[0m] %s\n" err
 
+
+(* f: a, b -> c ==> f: (a, b) -> c *)
+let curry f (a, b) = f a b
+let uncurry f a b = f (a, b)
+
+let split3 = function
+    | [] -> ([], [], [])
+    | (x, y, z) :: rest ->
+        let (xs, ys, zs) = go rest in
+        (x :: xs, y :: ys, z :: zs)

--- a/test/pat-tests/n-tuples-2.pat
+++ b/test/pat-tests/n-tuples-2.pat
@@ -1,0 +1,6 @@
+def main(): ((Bool * Int) * String) {
+    let (x, z) = ((1, "hello"), true) in
+    let (x1, x2) = x in
+    ((z, x1), x2)
+}
+main()

--- a/test/pat-tests/n-tuples-bad-1.pat
+++ b/test/pat-tests/n-tuples-bad-1.pat
@@ -1,0 +1,5 @@
+def main(): (Bool * Int * String) {
+    let (x, y) = (1, "hello", true) in
+    (true, x, y)
+}
+main()

--- a/test/pat-tests/n-tuples-bad-2.pat
+++ b/test/pat-tests/n-tuples-bad-2.pat
@@ -1,0 +1,5 @@
+def main(): (Bool * Int * String) {
+    let (x, y, z) = (1, "hello", true) in
+    (x, y, z)
+}
+main()

--- a/test/pat-tests/n-tuples.pat
+++ b/test/pat-tests/n-tuples.pat
@@ -1,0 +1,5 @@
+def main(): (Bool * Int * String) {
+    let (x, y, z) = (1, "hello", true) in
+    (z, x, y)
+}
+main()

--- a/test/tests.json
+++ b/test/tests.json
@@ -78,6 +78,26 @@
                     "name": "Atoms",
                     "filename": "pat-tests/atoms.pat",
                     "exit_code": 0
+                },
+                {
+                    "name": "n-tuples (1)",
+                    "filename": "pat-tests/n-tuples.pat",
+                    "exit_code": 0
+                },
+                {
+                    "name": "n-tuples (2)",
+                    "filename": "pat-tests/n-tuples-2.pat",
+                    "exit_code": 0
+                },
+                {
+                    "name": "n-tuples, bad (1)",
+                    "filename": "pat-tests/n-tuples-bad-1.pat",
+                    "exit_code": 1
+                },
+                {
+                    "name": "n-tuples, bad (2)",
+                    "filename": "pat-tests/n-tuples-bad-2.pat",
+                    "exit_code": 1
                 }
             ]
         },


### PR DESCRIPTION
This (surprisingly annoying-to-write?) PR generalises the pairs that we had previously to tuples of arbitrary length. This will be useful for the multiple mailboxes extension.

Note that currently we still can't do nested pattern matching: while we can construct `((1, 2), 3)`, we can't deconstruct it like `let ((x, y), z) = ((1, 2), 3) in y` just yet. One for another patch.

This patch also removes the unit constant and unit type (which are nullary tuples and the nullary tuple type respectively). 
To preserve backwards compatibility, `Unit` is now an alias for `()`.