### PR TITLE
Liberalise function pretypes to allow full return types

### DIFF
--- a/lib/common/pretype.ml
+++ b/lib/common/pretype.ml
@@ -9,9 +9,7 @@ open Util.Utility
 
 type t =
     | PBase of base
-    (* Functions are always annotated with argument types.
-       The codomain is a pretype, since it is not in binding position. *)
-    | PFun of { linear: bool; args: (Type.t[@name "ty"]) list; result: t[@name "pretype"] }
+    | PFun of { linear: bool; args: (Type.t[@name "ty"]) list; result: (Type.t[@name "ty"]) }
     | PInterface of string
     | PSum of (t * t)
     | PTuple of t list
@@ -31,7 +29,7 @@ let rec pp ppf =
         fprintf ppf "(%a) %s %a"
             (pp_print_comma_list Type.pp) args
             arrow
-            pp result
+            Type.pp result
     | PTuple ts ->
         let pp_star ppf () = pp_print_string ppf " * " in
         fprintf ppf "(%a)"
@@ -50,7 +48,7 @@ let show t =
 let rec of_type = function
     | Type.Base b -> PBase b
     | Type.Fun { linear; args; result } ->
-        PFun { linear; args; result = of_type result }
+        PFun { linear; args; result = result }
     | Type.Tuple ts -> PTuple (List.map of_type ts)
     | Type.Sum (t1, t2) -> PSum (of_type t1, of_type t2)
     | Type.Mailbox { interface; _ } -> PInterface interface
@@ -62,10 +60,7 @@ let rec of_type = function
 let rec to_type = function
     | PBase b -> Some (Type.Base b)
     | PFun { linear; args; result } ->
-        Option.bind (to_type result)
-        (fun result ->
-            Some (Type.Fun { linear; args; result })
-        )
+        Some (Type.Fun { linear; args; result })
     | PTuple ts ->
         let rec go acc =
             function

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -148,7 +148,10 @@ and check_val :
         match ty, pty with
             | Mailbox { interface; _ }, PInterface iname when interface = iname -> ()
             | Base b1, PBase b2 when b1 = b2 -> ()
-            | Fun _, PFun _ ->  () (* TODO: might want some more checking here -- equality might not be enough? *)
+            | Fun _, PFun _ -> 
+                (* Function pretypes are now fully typed, so any errors will be
+                   picked up in constraint generation or constraint resolution. *)
+                ()
             | Tuple ts, PTuple pts ->
                 List.combine ts pts
                 |> List.iter (uncurry check_pretype_consistency)

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -60,20 +60,9 @@ let rec synthesise_val :
                         ty, Ty_env.singleton v ty, Constraint_set.empty
                     (* In limited circumstances we can use a pretype annotation to
                        synthesise a function *)
-                    | _, PFun { linear; args; result = PBase b } ->
-                        let ty = Type.function_type linear args (Type.Base b) in
+                    | _, PFun { linear; args; result } ->
+                        let ty = Type.function_type linear args result in
                         ty, Ty_env.singleton v ty, Constraint_set.empty
-                    (* Units *)
-                    | _, PFun { linear; args; result = PTuple [] } ->
-                            let ty = Type.function_type linear args (Type.Tuple []) in
-                        ty, Ty_env.singleton v ty, Constraint_set.empty
-                    | _, PFun _ ->
-                        Gripers.synth_mailbox_function v [pos]
-                    (* Although we have an interface pretype annotation, it's not possible
-                       to reliably infer a mailbox type (even with a fresh constraint) since
-                       we don't, a priori, know the capability. Even if we record the initial
-                       capability, it may be used at different 'modes' throughout the function,
-                       so any inference would in effect be a guess. *)
                     | _, _ ->
                         Gripers.synth_variable v [pos]
             end
@@ -159,8 +148,7 @@ and check_val :
         match ty, pty with
             | Mailbox { interface; _ }, PInterface iname when interface = iname -> ()
             | Base b1, PBase b2 when b1 = b2 -> ()
-            | Fun { result = rty; _ }, PFun { result = rpty; _ } ->
-                check_pretype_consistency rty rpty
+            | Fun _, PFun _ ->  () (* TODO: might want some more checking here -- equality might not be enough? *)
             | Tuple ts, PTuple pts ->
                 List.combine ts pts
                 |> List.iter (uncurry check_pretype_consistency)

--- a/lib/typecheck/gripers.ml
+++ b/lib/typecheck/gripers.ml
@@ -12,14 +12,6 @@ let synth_variable v pos_list =
     in
     raise (constraint_gen_error ~subsystem:(Errors.GenSynth) msg pos_list)
 
-let synth_mailbox_function v pos_list =
-    let msg =
-        Format.asprintf
-            "Cannot synthesise type for variable %a: can only synthesise types for functions which return a base type" Ir.Var.pp_name v
-    in
-    raise (constraint_gen_error ~subsystem:(Errors.GenSynth) msg pos_list)
-
-
 let subtype_cap_mismatch t1 t2 pos_list =
     let msg =
       Format.asprintf

--- a/lib/typecheck/pretypecheck.ml
+++ b/lib/typecheck/pretypecheck.ml
@@ -148,14 +148,13 @@ let rec synthesise_val ienv env value : (value * Pretype.t) =
                     (fun (b, ty) -> Var.of_binder b, Pretype.of_type ty)
                     parameters
             in
-            let result_prety = Pretype.of_type result_type in
             let env = PretypeEnv.bind_many pretype_params env in
-            let body = check_comp ienv env body result_prety in
+            let body = check_comp ienv env body (Pretype.of_type result_type) in
             wrap (Lam { linear; parameters; body; result_type }),
             Pretype.PFun {
                 linear = linear;
                 args = param_types;
-                result = result_prety
+                result = result_type 
             }
         | Inl _ | Inr _ -> Gripers.cannot_synth_sum value
 and check_val ienv env value ty =
@@ -279,7 +278,7 @@ and synthesise_comp ienv env comp =
                     check_val ienv env arg arg_ty)
             in
             (* Synthesise result type *)
-            WithPos.make ~pos(App { func; args }), result_ann
+            WithPos.make ~pos(App { func; args }), Pretype.of_type result_ann
         | Send { target; message = (tag, vals); _ } ->
             let open Pretype in
             (* Typecheck target *)
@@ -428,7 +427,7 @@ let check { prog_interfaces; prog_decls; prog_body } =
                 Pretype.PFun {
                     linear = false;
                     args = param_tys;
-                    result = Pretype.of_type d.decl_return_type
+                    result = d.decl_return_type
                 })) (WithPos.extract_list_node prog_decls)
         |> PretypeEnv.from_list
     in

--- a/test/pat-tests/mb-function-return.pat
+++ b/test/pat-tests/mb-function-return.pat
@@ -1,0 +1,8 @@
+interface Test { }
+
+def main(): Unit {
+    let f = fun(x: Test?): Test? { x } in
+    free(f(new[Test]))
+}
+
+main()

--- a/test/tests.json
+++ b/test/tests.json
@@ -22,6 +22,11 @@
                     "name": "Linear function (bad #3: unused linear function)",
                     "filename": "pat-tests/linfun-bad-3.pat",
                     "exit_code": 1
+                },
+                {
+                    "name": "Function returning a mailbox type",
+                    "filename": "pat-tests/mb-function-return.pat",
+                    "exit_code": 0
                 }
             ]
         },


### PR DESCRIPTION
Since functions are fully annotated (including with a result type), we can liberalise function pretypes from `Type.t list -> Pretype.t` to `Type.t list -> Type.t`. In turn this allows us to do things like returning a mailbox type from an anonymous function. It also simplifies the logic in the variable synthesis case.