### PR TITLE
Datatype updates

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -23,13 +23,14 @@ let print_ir (prog, _prety, ir, _ty, _env, _constrs) =
         "=== Intermediate Representation: ===\n%a\n\n"
         (Ir.pp_program) ir
 
-let process filename is_verbose is_debug is_ir mode benchmark_count disable_ql use_join () =
+let process filename is_verbose is_debug is_ir mode benchmark_count disable_ql use_join returnable_dts () =
     Settings.(set verbose is_verbose);
     Settings.(set debug is_debug);
     Settings.(set receive_typing_strategy mode);
     Settings.(set benchmark benchmark_count);
     Settings.(set disable_quasilinearity disable_ql);
     Settings.(set join_not_combine use_join);
+    Settings.(set returnable_datatypes returnable_dts);
     try
         Frontend.Parse.parse_file filename ()
         |> Frontend.Pipeline.pipeline
@@ -53,6 +54,7 @@ let () =
       ~docv:"BENCHMARK" ~doc:"number of repetitions for benchmark; -1 (default) for no benchmarking")
     $ Arg.(value & flag & info ["q"; "disable-quasilinearity"] ~doc:"disable quasilinearity checking")
     $ Arg.(value & flag & info ["j"; "join-not-combine"] ~doc:"use sequential join for value subterms, rather than requiring disjointness")
+    $ Arg.(value & flag & info ["dt"; "returnable-datatypes"] ~doc:"require data contained in datatypes to be returnable")
     $ const ()) in
   let info = Cmd.info "mbcheck" ~doc:"Typechecker for mailbox calculus" in
   Cmd.v info mbcheck_t

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -23,14 +23,14 @@ let print_ir (prog, _prety, ir, _ty, _env, _constrs) =
         "=== Intermediate Representation: ===\n%a\n\n"
         (Ir.pp_program) ir
 
-let process filename is_verbose is_debug is_ir mode benchmark_count disable_ql use_join returnable_dts () =
+let process filename is_verbose is_debug is_ir mode benchmark_count disable_ql use_join liberal_dts () =
     Settings.(set verbose is_verbose);
     Settings.(set debug is_debug);
     Settings.(set receive_typing_strategy mode);
     Settings.(set benchmark benchmark_count);
     Settings.(set disable_quasilinearity disable_ql);
     Settings.(set join_not_combine use_join);
-    Settings.(set returnable_datatypes returnable_dts);
+    Settings.(set liberal_datatypes liberal_dts);
     try
         Frontend.Parse.parse_file filename ()
         |> Frontend.Pipeline.pipeline
@@ -54,7 +54,7 @@ let () =
       ~docv:"BENCHMARK" ~doc:"number of repetitions for benchmark; -1 (default) for no benchmarking")
     $ Arg.(value & flag & info ["q"; "disable-quasilinearity"] ~doc:"disable quasilinearity checking")
     $ Arg.(value & flag & info ["j"; "join-not-combine"] ~doc:"use sequential join for value subterms, rather than requiring disjointness")
-    $ Arg.(value & flag & info ["dt"; "returnable-datatypes"] ~doc:"require data contained in datatypes to be returnable")
+    $ Arg.(value & flag & info ["dt"; "returnable-datatypes"] ~doc:"allow data contained in datatypes to be usable (may impact soundness)")
     $ const ()) in
   let info = Cmd.info "mbcheck" ~doc:"Typechecker for mailbox calculus" in
   Cmd.v info mbcheck_t

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -55,7 +55,7 @@ let () =
       ~docv:"BENCHMARK" ~doc:"number of repetitions for benchmark; -1 (default) for no benchmarking")
     $ Arg.(value & flag & info ["q"; "disable-quasilinearity"] ~doc:"disable quasilinearity checking")
     $ Arg.(value & flag & info ["j"; "join-not-combine"] ~doc:"use sequential join for value subterms, rather than requiring disjointness")
-    $ Arg.(value & flag & info ["dt"; "returnable-datatypes"] ~doc:"allow data contained in datatypes to be usable (may impact soundness)")
+    $ Arg.(value & flag & info ["dt"; "liberal-datatypes"] ~doc:"allow data contained in datatypes to be usable (may impact soundness)")
     $ const ()) in
   let info = Cmd.info "mbcheck" ~doc:"Typechecker for mailbox calculus" in
   Cmd.v info mbcheck_t

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -23,9 +23,10 @@ let print_ir (prog, _prety, ir, _ty, _env, _constrs) =
         "=== Intermediate Representation: ===\n%a\n\n"
         (Ir.pp_program) ir
 
-let process filename is_verbose is_debug is_ir mode benchmark_count disable_ql use_join liberal_dts () =
+let process filename is_verbose is_debug should_show_ir mode benchmark_count disable_ql use_join liberal_dts () =
     Settings.(set verbose is_verbose);
     Settings.(set debug is_debug);
+    Settings.(set show_ir should_show_ir);
     Settings.(set receive_typing_strategy mode);
     Settings.(set benchmark benchmark_count);
     Settings.(set disable_quasilinearity disable_ql);
@@ -34,7 +35,7 @@ let process filename is_verbose is_debug is_ir mode benchmark_count disable_ql u
     try
         Frontend.Parse.parse_file filename ()
         |> Frontend.Pipeline.pipeline
-        |> (if is_ir then print_ir else print_result)
+        |> print_result
     with
         | e ->
             Errors.format_error e;
@@ -47,7 +48,7 @@ let () =
     $ Arg.(required & pos 0 (some string) None & info [] ~docv:"FILENAME")
     $ Arg.(value & flag & info ["v"; "verbose"] ~doc:"verbose typechecking information")
     $ Arg.(value & flag & info ["d"; "debug"] ~doc:"print debug information")
-    $ Arg.(value & flag & info ["ir"] ~doc:"print the parsed program and its IR translation")
+    $ Arg.(value & flag & info ["ir"] ~doc:"print the translated IR")
     $ Arg.(value & opt (enum Settings.ReceiveTypingStrategy.enum) Settings.ReceiveTypingStrategy.Interface & info ["mode"]
       ~docv:"MODE" ~doc:"typechecking mode for receive blocks (allowed: strict, interface, none)")
     $ Arg.(value & opt int (-1) & info ["b"; "benchmark"]

--- a/lib/common/errors.ml
+++ b/lib/common/errors.ml
@@ -25,6 +25,7 @@ let show_subsystem = function
 (* Exceptions *)
 exception Parse_error of string * Position.t list
 exception Pretype_error of string * Position.t list
+exception Desugar_error of string * Position.t list
 exception Type_error of string * Position.t list (* Used for errors common to both pretyping and constraint generation *)
 exception Constraint_gen_error of { subsystem: subsystem option; message: string; pos_list: Position.t list  }
 (* It would be a bit nicer to have the constraints on the LHS and RHS here,
@@ -43,6 +44,8 @@ let constraint_solver_error lhs rhs = Constraint_solver_error { lhs; rhs }
 let constraint_solver_zero_error var = Constraint_solver_zero_error var
 let bad_receive_typing_argument bad = Bad_receive_typing_argument bad
 let transform_error err pos_list = Transform_error (err, pos_list)
+let desugar_error err pos_list = Desugar_error (err, pos_list)
+
 
 (* Will likely be more interesting when we have positional information *)
 let format_error = function
@@ -55,6 +58,9 @@ let format_error = function
     | Pretype_error (s, pos_list) ->
         let pos_info = Position.format_pos pos_list in
         Utility.print_error ~note:"PRETYPE" (s ^ " \n " ^ pos_info)
+    | Desugar_error (s, pos_list) ->
+        let pos_info = Position.format_pos pos_list in
+        Utility.print_error ~note:"DESUGAR" (s ^ " \n " ^ pos_info)
     | Transform_error (s, pos_list) ->
         let pos_info = Position.format_pos pos_list in
         Utility.print_error ~note:"TRANSFORM" (s ^ " \n " ^ pos_info)

--- a/lib/common/lib_types.ml
+++ b/lib/common/lib_types.ml
@@ -23,6 +23,7 @@ let signatures =
         ("print", function_type false [Base Base.String] Type.unit_type);
         ("concat", function_type false [Base Base.String; Base Base.String] Type.string_type);
         ("rand", function_type false [Base Base.Int] (Base Base.Int));
+        ("randBool", function_type false [] (Base Base.Bool));
         ("sleep", function_type false [Base Base.Int] Type.unit_type);
         ("intToString", function_type false [Base Base.Int] (Base Base.String))
     ]

--- a/lib/common/pretype.ml
+++ b/lib/common/pretype.ml
@@ -57,6 +57,7 @@ let rec of_type = function
     | Type.Sum (t1, t2) -> PSum (of_type t1, of_type t2)
     | Type.List t -> PList (of_type t)
     | Type.Mailbox { interface; _ } -> PInterface interface
+    | Type.UserMailbox { umb_interface; _ } -> PInterface umb_interface
 
 (* As long as a pretype isn't a mailbox type, and isn't a function
     returning a mailbox type, we can upgrade it to a type.

--- a/lib/common/settings.ml
+++ b/lib/common/settings.ml
@@ -12,6 +12,7 @@ let verbose = ref false
 let debug = ref false
 let benchmark = ref (-1)
 let receive_typing_strategy = ref ReceiveTypingStrategy.Interface
+let returnable_datatypes = ref false
 let disable_quasilinearity = ref false
 let join_not_combine = ref false
 

--- a/lib/common/settings.ml
+++ b/lib/common/settings.ml
@@ -12,7 +12,7 @@ let verbose = ref false
 let debug = ref false
 let benchmark = ref (-1)
 let receive_typing_strategy = ref ReceiveTypingStrategy.Interface
-let returnable_datatypes = ref false
+let liberal_datatypes = ref false
 let disable_quasilinearity = ref false
 let join_not_combine = ref false
 

--- a/lib/common/settings.ml
+++ b/lib/common/settings.ml
@@ -15,6 +15,7 @@ let receive_typing_strategy = ref ReceiveTypingStrategy.Interface
 let liberal_datatypes = ref false
 let disable_quasilinearity = ref false
 let join_not_combine = ref false
+let show_ir = ref true
 
 let set : 'a setting -> 'a -> unit = fun setting value ->
     setting := value

--- a/lib/common/settings.mli
+++ b/lib/common/settings.mli
@@ -12,6 +12,7 @@ val benchmark : int setting
 val receive_typing_strategy : ReceiveTypingStrategy.t setting
 val disable_quasilinearity : bool setting
 val join_not_combine : bool setting
+val returnable_datatypes  : bool setting
 
 val set : 'a setting -> 'a -> unit
 val get : 'a setting -> 'a

--- a/lib/common/settings.mli
+++ b/lib/common/settings.mli
@@ -13,6 +13,7 @@ val receive_typing_strategy : ReceiveTypingStrategy.t setting
 val disable_quasilinearity : bool setting
 val join_not_combine : bool setting
 val liberal_datatypes  : bool setting
+val show_ir : bool setting
 
 val set : 'a setting -> 'a -> unit
 val get : 'a setting -> 'a

--- a/lib/common/settings.mli
+++ b/lib/common/settings.mli
@@ -12,7 +12,7 @@ val benchmark : int setting
 val receive_typing_strategy : ReceiveTypingStrategy.t setting
 val disable_quasilinearity : bool setting
 val join_not_combine : bool setting
-val returnable_datatypes  : bool setting
+val liberal_datatypes  : bool setting
 
 val set : 'a setting -> 'a -> unit
 val get : 'a setting -> 'a

--- a/lib/common/sugar_ast.ml
+++ b/lib/common/sugar_ast.ml
@@ -310,3 +310,17 @@ let substitute_solution sol =
         end
     in
     visitor#visit_program ()
+
+
+let rec is_syntactic_value x =
+    match WithPos.node x with
+        | Var _
+        | Atom _
+        | Primitive _
+        | Constant _
+        | Nil
+        | Lam _ -> true
+        | Cons (x, xs) -> is_syntactic_value x && is_syntactic_value xs
+        | Tuple xs -> List.for_all is_syntactic_value xs
+        | Inl x | Inr x -> is_syntactic_value x
+        | _ -> false

--- a/lib/common/type.ml
+++ b/lib/common/type.ml
@@ -442,14 +442,12 @@ let get_quasilinearity = function
 
 let make_usable = function
     | Mailbox m -> Mailbox { m with quasilinearity = Quasilinearity.Usable }
-    | UserMailbox m -> UserMailbox { m with umb_quasilinearity = Some Quasilinearity.Usable }
     | t -> t
 
 (* Tuples, sums, and lists can all be returnable even if they contain things that are not returnable,
    as long as we are careful to avoid aliasing when deconstructing the value. *)
 let make_returnable = function
     | Mailbox m -> Mailbox { m with quasilinearity = Quasilinearity.Returnable }
-    | UserMailbox m -> UserMailbox { m with umb_quasilinearity = Some Quasilinearity.Returnable }
     | t -> t
 
 let is_unr = is_lin >> not
@@ -463,9 +461,15 @@ let make_function_type linear args result =
     Fun { linear; args; result }
 
 let make_tuple_type tys =
-    Tuple (List.map make_returnable tys)
+    if Settings.(get liberal_datatypes) then
+        Tuple tys
+    else
+        Tuple (List.map make_returnable tys)
 
 let make_sum_type ty1 ty2 =
-    Sum (make_returnable ty1, make_returnable ty2)
+    if Settings.(get liberal_datatypes) then
+        Sum (ty1, ty2)
+    else
+        Sum (make_returnable ty1, make_returnable ty2)
 
 let make_list_type ty = List ty

--- a/lib/common/type.ml
+++ b/lib/common/type.ml
@@ -440,15 +440,29 @@ let get_quasilinearity = function
     | UserMailbox { umb_quasilinearity = Some ql; _ } -> ql
     | _ -> raise (Errors.internal_error "type.ml" "attempted to get quasilinearity of non-mailbox type")
 
-let make_usable = function
+(* make_usable always defined on datatypes in order to ensure spawn masking works *)
+let rec make_usable = function
     | Mailbox m -> Mailbox { m with quasilinearity = Quasilinearity.Usable }
+    | List t -> List (make_usable t)
+    | Tuple ts -> Tuple (List.map make_usable ts)
+    | Sum (t1, t2) -> Sum (make_usable t1, make_usable t2)
     | t -> t
 
-(* Tuples, sums, and lists can all be returnable even if they contain things that are not returnable,
-   as long as we are careful to avoid aliasing when deconstructing the value. *)
-let make_returnable = function
+(* make_returnable propagates returnability to datatype components
+   if liberal datatypes is off; otherwise it leaves them untouched *)
+let rec make_returnable = function
     | Mailbox m -> Mailbox { m with quasilinearity = Quasilinearity.Returnable }
-    | t -> t
+    | ty ->
+        begin
+            if not <| Settings.(get liberal_datatypes) then
+                match ty with
+                    | List t -> List (make_returnable t)
+                    | Tuple ts -> Tuple (List.map make_returnable ts)
+                    | Sum (t1, t2) -> Sum (make_returnable t1, make_returnable t2)
+                    | _ -> ty
+            else ty
+        end
+    
 
 let is_unr = is_lin >> not
 

--- a/lib/common/type.ml
+++ b/lib/common/type.ml
@@ -255,6 +255,16 @@ type t =
     | Tuple of t list
     | Sum of (t * t)
     | List of t
+    (* User-written mailbox type. May not have specified QL and pattern.
+       This will be desugared before IR conversion. *)
+    | UserMailbox of {
+        umb_capability: (Capability.t [@name "capability"]);
+        umb_interface: string;
+        umb_quasilinearity: (Quasilinearity.t [@name "quasilinearity"]) option;
+        umb_pattern: (Pattern.t [@name "pattern"]) option
+
+    }
+    (* Mailbox type after desugaring, or produced during TC *)
     | Mailbox of {
         capability: (Capability.t [@name "capability"]);
         interface: string;
@@ -270,9 +280,7 @@ type t =
            circumvent syntactic checks.
          *)
         quasilinearity: (Quasilinearity.t [@name "quasilinearity"]);
-        (* Annotations need not specify a mailbox pattern, leaving it
-           to be inferred. *)
-        pattern: (Pattern.t [@name "pattern"]) option
+        pattern: (Pattern.t [@name "pattern"])
     }
     [@@name "ty"]
 and base = [%import: Common_types.Base.t]
@@ -306,7 +314,7 @@ let mailbox_send_unit interface quasilinearity =
     Mailbox {
         capability = Capability.Out;
         interface;
-        pattern = Some (Pattern.One);
+        pattern = Pattern.One;
         quasilinearity
     }
 
@@ -337,15 +345,33 @@ let rec pp ppf =
                 | Quasilinearity.Returnable -> "R"
                 | Quasilinearity.Usable -> "U"
         in
-        let op =
+        let cap =
             match capability with
                 | Capability.In -> "?"
                 | Capability.Out -> "!"
         in
         fprintf ppf "%s%s(%a)[%s]"
             interface
-            op
-            (pp_print_option pp_pattern) pattern
+            cap
+            pp_pattern pattern
+            ql
+    | UserMailbox { umb_capability; umb_interface;
+            umb_pattern; umb_quasilinearity } ->
+        let ql =
+            match umb_quasilinearity with
+                | Some (Quasilinearity.Returnable) -> "[R]"
+                | Some (Quasilinearity.Usable) -> "[U]"
+                | None -> ""
+        in
+        let cap =
+            match umb_capability with
+                | Capability.In -> "?"
+                | Capability.Out -> "!"
+        in
+        fprintf ppf "%s%s(%a)%s"
+            umb_interface
+            cap
+            (pp_print_option pp_pattern) umb_pattern
             ql
 and pp_capability = Capability.pp
 and pp_base = Base.pp
@@ -361,23 +387,26 @@ let rec is_lin = function
     | Base _ -> false
     | Fun { linear; _ } -> linear
     (* !1 is unrestricted... *)
-    | Mailbox { capability = Out; pattern = Some One; _ } -> false
+    | Mailbox { capability = Out; pattern = One; _ } -> false
     | Tuple ts -> List.exists is_lin ts
     | Sum (t1, t2) -> is_lin t1 || is_lin t2
     | List t -> is_lin t
     (* ...but otherwise a mailbox type must be used linearly. *)
     | Mailbox _ -> true
+    | UserMailbox _ -> assert false
 
 let is_input_mailbox = function
-    | Mailbox { capability = In; pattern = Some _; _ } -> true
+    | Mailbox { capability = In; _ } -> true
     | _ -> false
 
 let is_output_mailbox = function
-    | Mailbox { capability = Out; pattern = Some _; _ } -> true
+    | Mailbox { capability = Out; _ } -> true
+    | UserMailbox { umb_capability = Out; _ } -> true
     | _ -> false
 
 let rec contains_output_mailbox = function
-    | Mailbox { capability = Out; pattern = Some _; _} -> true
+    | Mailbox { capability = Out; _} -> true
+    | UserMailbox { umb_capability = Out; _} -> true
     | Sum (t1, t2) -> contains_output_mailbox t1 || contains_output_mailbox t2
     | Tuple ts -> List.exists contains_output_mailbox ts
     | List t -> contains_output_mailbox t
@@ -396,26 +425,31 @@ let is_list = function
   | _ -> false
 
 let get_pattern = function
-    | Mailbox { pattern = Some pat; _ } -> pat
+    | Mailbox { pattern = pat; _ } -> pat
+    | UserMailbox { umb_pattern = Some pat; _ } -> pat
     | _ -> raise (Errors.internal_error "type.ml" "attempted to get pattern of non-mailbox type")
 
 let get_interface = function
-    | Mailbox { interface = iface; _ } -> iface
+    | Mailbox { interface = iface; _ }
+    | UserMailbox { umb_interface = iface; _ } -> iface
     | _ -> raise (Errors.internal_error "type.ml" "attempted to get interface of non-mailbox type")
 
 
 let get_quasilinearity = function
     | Mailbox { quasilinearity; _ } -> quasilinearity
+    | UserMailbox { umb_quasilinearity = Some ql; _ } -> ql
     | _ -> raise (Errors.internal_error "type.ml" "attempted to get quasilinearity of non-mailbox type")
 
 let make_usable = function
     | Mailbox m -> Mailbox { m with quasilinearity = Quasilinearity.Usable }
+    | UserMailbox m -> UserMailbox { m with umb_quasilinearity = Some Quasilinearity.Usable }
     | t -> t
 
 (* Tuples, sums, and lists can all be returnable even if they contain things that are not returnable,
    as long as we are careful to avoid aliasing when deconstructing the value. *)
 let make_returnable = function
     | Mailbox m -> Mailbox { m with quasilinearity = Quasilinearity.Returnable }
+    | UserMailbox m -> UserMailbox { m with umb_quasilinearity = Some Quasilinearity.Returnable }
     | t -> t
 
 let is_unr = is_lin >> not

--- a/lib/frontend/desugar_let_annotations.ml
+++ b/lib/frontend/desugar_let_annotations.ml
@@ -1,5 +1,5 @@
 (*
-    let x: A = M in N --> let x = (M : (returnable(A))) in N
+    let x: A = M in N --> let x = (M : (make_returnable(A))) in N
  *)
 open Common
 

--- a/lib/frontend/desugar_sugared_guards.ml
+++ b/lib/frontend/desugar_sugared_guards.ml
@@ -1,5 +1,6 @@
 (*
-    fail(M)[A] ---> guard e : 0 { fail[A] }
+    free(x) |-> M ---> empty(x) |-> free(x)
+    fail(M)[A]    ---> guard e : 0 { fail[A] }
  *)
 open Common
 

--- a/lib/frontend/insert_pattern_variables.ml
+++ b/lib/frontend/insert_pattern_variables.ml
@@ -2,8 +2,12 @@
 (* Annotation takes partially-defined mailbox types (i.e., MB types with
  * interface information but no pattern annotations) and annotates them with
  * fresh pattern variables so that we can generate constraints.
- * This is done for all types that are in binding position.  *)
-(* Additionally, for interfaces, sets the quasilinearity to Usable. *)
+ * This is done for all user-specified mailbox types. *)
+(* Additionally, for interfaces, sets default quasilinearity: if unspecified,
+   sets QL to reasonable defaults:
+     - Returnable for mailbox types in datatype annotations
+     - Usable for ! mailbox types
+ *)
 open Common
 open Sugar_ast
 open Source_code
@@ -12,6 +16,7 @@ let rec annotate_type =
     let open Type in
     function
         | Base t -> Base t
+        | Mailbox mb -> Mailbox mb
         | Fun { linear; args; result } ->
             Fun {
                 linear;
@@ -19,39 +24,93 @@ let rec annotate_type =
                 result = annotate_type result
             }
         | Tuple ts ->
-            Tuple (List.map annotate_type ts)
+            Tuple (List.map annotate_type_as_returnable ts)
         | Sum (t1, t2) ->
-            Sum (annotate_type t1, annotate_type t2)
+            Sum (annotate_type_as_returnable t1, annotate_type_as_returnable t2)
         | List t ->
-            List (annotate_type t)
-        | Mailbox { pattern = Some _; _ } as mb -> mb
-        | Mailbox { capability; interface; pattern = None; quasilinearity } ->
-            Mailbox {
-                capability;
-                interface;
-                pattern = Some (Pattern.fresh ());
-                quasilinearity
-            }
+            List (annotate_type_as_returnable t)
+        | UserMailbox { 
+            umb_capability;
+            umb_interface;
+            umb_quasilinearity;
+            umb_pattern
+          } ->
+              (* Sensible default QL is usable for ! and returnable for ? *)
+              let quasilinearity =
+                  let open Capability in
+                  match (umb_quasilinearity, umb_capability) with
+                    | (Some ql, _) -> ql
+                    | (None, Out) -> Usable
+                    | (None, In) -> Returnable
+              in
+              let pattern =
+                  match umb_pattern with
+                    | Some p -> p
+                    | None -> Pattern.fresh ()
+              in
+              Mailbox { capability = umb_capability; interface = umb_interface;
+                    quasilinearity; pattern }
 
-let annotate_interface_type =
+(* Biased annotation that will default to annotating QL as returnable if
+    undefined *)
+and annotate_type_as_returnable =
     let open Type in
     function
-        (* Outermost MB types (i.e., payloads) are treated as usable. *)
-        | Mailbox { pattern = Some _; _ } as mb -> mb
-        | Mailbox { capability; interface; pattern = None; _ } ->
+        | UserMailbox { umb_capability; umb_interface;
+                umb_pattern; umb_quasilinearity } ->
+            let pattern =
+                match umb_pattern with
+                    | Some p -> p
+                    | None -> Pattern.fresh ()
+            in
+            let quasilinearity =
+                match umb_quasilinearity with
+                    | Some ql -> ql
+                    | None -> Quasilinearity.Returnable
+            in
             Mailbox {
-                capability;
-                interface;
-                pattern = Some (Pattern.fresh ());
+                capability = umb_capability;
+                interface = umb_interface;
+                pattern;
+                quasilinearity
+            }
+        | List t -> List (annotate_type_as_returnable t)
+        | Tuple ts -> Tuple (List.map annotate_type_as_returnable ts)
+        | Sum (t1, t2) -> Sum (annotate_type_as_returnable t1, annotate_type_as_returnable t2)
+        | t -> annotate_type t
+
+let annotate_interface_type pos ty =
+    let open Type in
+    match ty with
+        (* Outermost MB types (i.e., payloads) are treated as usable. *)
+        | UserMailbox { umb_quasilinearity = Some _ ; _ } ->
+            raise (Errors.desugar_error
+                "Mailbox message payloads cannot be returnable."
+                [pos]
+            )
+        | UserMailbox { umb_capability; umb_interface; umb_pattern; _ } ->
+            let pattern =
+                match umb_pattern with
+                    | Some pat -> pat
+                    | None -> Pattern.fresh ()
+            in
+            Mailbox {
+                capability = umb_capability;
+                interface = umb_interface;
+                pattern;
                 quasilinearity = Quasilinearity.Usable
             }
+        | Mailbox mb -> Mailbox mb
         | t -> annotate_type t
 
 (* Annotates all types in an interface *)
 let annotate_interface iface =
-    Interface.bindings iface
-    |> List.map (fun (tag, tys) -> (tag, List.map annotate_interface_type tys))
-    |> Interface.(make (name iface))
+    let iface_pos = WithPos.pos iface in
+    let iface_node = WithPos.node iface in
+    Interface.bindings iface_node
+    |> List.map (fun (tag, tys) ->
+            (tag, List.map (annotate_interface_type iface_pos) tys))
+    |> Interface.(make (name iface_node))
 
 (* The visitor traverses the AST to annotate parameters of higher-order
    functions. *)
@@ -89,15 +148,15 @@ let visitor =
                 let new_let = Let { annot = Some ty; binder; term; body } in
                 { expr_with_pos with node = new_let }
             | LetTuple { annot = Some tys; binders; term; cont } ->
-                let tys = List.map annotate_type tys in
+                let tys = List.map annotate_type_as_returnable tys in
                 let term = self#visit_expr env term in
                 let cont = self#visit_expr env cont in
                 let new_let = LetTuple { annot = Some tys; binders; term; cont } in
                 { expr_with_pos with node = new_let }
             | Case { term; branch1 = ((bnd1, ty1), e1); branch2 = ((bnd2, ty2), e2) } ->
                 let term = self#visit_expr env term in
-                let ty1 = annotate_type ty1 in
-                let ty2 = annotate_type ty2 in
+                let ty1 = annotate_type_as_returnable ty1 in
+                let ty2 = annotate_type_as_returnable ty2 in
                 let e1 = self#visit_expr env e1 in
                 let e2 = self#visit_expr env e2 in
                 let new_case = Case {
@@ -106,7 +165,7 @@ let visitor =
                 { expr_with_pos with node = new_case }
             | CaseL { term; ty = ty1; nil = nil_cont; cons = ((x_bnd, xs_bnd), cons_cont)} ->
                 let term = self#visit_expr env term in
-                let ty_ann = annotate_type ty1 in
+                let ty_ann = annotate_type_as_returnable ty1 in
                 let nil_cont = self#visit_expr env nil_cont in
                 let cons_cont = self#visit_expr env cons_cont in
                 let new_case =
@@ -122,7 +181,7 @@ let visitor =
 
         method! visit_program env p =
             let prog_interfaces =
-                List.map annotate_interface (WithPos.extract_list_node p.prog_interfaces) in
+                List.map annotate_interface p.prog_interfaces in
             let prog_interfaces_with_pos =
                 List.map2 (fun iface pos -> WithPos.make ~pos iface) prog_interfaces (List.map WithPos.pos p.prog_interfaces) in
             let prog_decls =

--- a/lib/frontend/parser.mly
+++ b/lib/frontend/parser.mly
@@ -306,25 +306,19 @@ ql:
 
 mailbox_ty:
     | CONSTRUCTOR BANG simple_pat? ql? {
-        let quasilinearity =
-            Option.value $4 ~default:(Type.Quasilinearity.Usable)
-        in
-        Type.(Mailbox {
-            capability = Capability.Out;
-            interface = $1;
-            pattern = $3;
-            quasilinearity
+        Type.(UserMailbox {
+            umb_capability = Capability.Out;
+            umb_interface = $1;
+            umb_pattern = $3;
+            umb_quasilinearity = $4
         })
     }
     | CONSTRUCTOR QUERY simple_pat? ql? {
-        let quasilinearity =
-            Option.value $4 ~default:(Type.Quasilinearity.Returnable)
-        in
-        Type.(Mailbox {
-            capability = Capability.In;
-            interface = $1;
-            pattern = $3;
-            quasilinearity
+        Type.(UserMailbox {
+            umb_capability = Capability.In;
+            umb_interface = $1;
+            umb_pattern = $3;
+            umb_quasilinearity = $4
         })
     }
 

--- a/lib/frontend/pipeline.ml
+++ b/lib/frontend/pipeline.ml
@@ -7,9 +7,12 @@ let desugar p =
     |> Desugar_sugared_guards.desugar
 
 let typecheck p ir = 
-    Format.printf
-        "=== Intermediate Representation: ===\n%a\n\n"
-        (Ir.pp_program) ir;
+    let () =
+        if Settings.(get show_ir) then
+            Format.printf
+                "=== Intermediate Representation: ===\n%a\n\n"
+                (Ir.pp_program) ir
+    in
     let ir, prety_opt = Typecheck.Pretypecheck.check ir in
     let (ty, env, constrs) = Typecheck.Gen_constraints.synthesise_program ir in
     let solution = Typecheck.Solve_constraints.solve_constraints constrs in

--- a/lib/frontend/pipeline.ml
+++ b/lib/frontend/pipeline.ml
@@ -2,16 +2,14 @@ open Common
 
 let desugar p =
     p
+    |> Insert_pattern_variables.annotate
     |> Desugar_let_annotations.desugar
     |> Desugar_sugared_guards.desugar
-    |> Insert_pattern_variables.annotate
 
 let typecheck p ir = 
-    (*
     Format.printf
         "=== Intermediate Representation: ===\n%a\n\n"
         (Ir.pp_program) ir;
-        *)
     let ir, prety_opt = Typecheck.Pretypecheck.check ir in
     let (ty, env, constrs) = Typecheck.Gen_constraints.synthesise_program ir in
     let solution = Typecheck.Solve_constraints.solve_constraints constrs in

--- a/lib/frontend/sugar_to_ir.ml
+++ b/lib/frontend/sugar_to_ir.ml
@@ -114,8 +114,13 @@ and transform_expr :
                 result_type;
                 body = transform_expr env' body id }))) |> k env
         | Annotate (body, annotation) ->
-            with_same_pos (Ir.Annotate (transform_expr env body id, annotation))
-            |> k env
+            if Sugar_ast.is_syntactic_value body then
+                transform_subterm env
+                    body 
+                    (fun env v -> with_same_pos (Ir.Return (with_same_pos (Ir.VAnnotate (v, annotation)))) |> k env)
+            else
+                with_same_pos (Ir.Annotate (transform_expr env body id, annotation))
+                |> k env
         | Inl e ->
             transform_subterm env e (fun env v -> with_same_pos (Ir.Return (with_same_pos (Ir.Inl v))) |> k env)
         | Inr e ->
@@ -231,7 +236,53 @@ and transform_expr :
                 }) |> k env )
         |  SugarFail (_, _) -> (* shouldn't ever match *)
                 raise (Errors.internal_error "sugar_to_ir.ml" "Encountered SugarFree/SugarFail expression during the IR translation stage")
-
+(* Transforms an expression into a syntactic value, if possible *)
+and transform_syntactic_value
+    (env: env)
+    pos
+    (x: Sugar_ast.expr)
+    (* : Ir.value option *)
+    =
+    let wrap v = WithPos.make ~pos v in
+    match WithPos.node x with
+        | Var var ->
+             let v = lookup_var var env pos in
+             Some (wrap @@ Ir.Variable (v, None))
+        | Atom x -> Some (wrap @@ Ir.Atom x)
+        | Primitive x -> Some (wrap @@ Ir.Primitive x)
+        | Constant x -> Some (wrap @@ Ir.Constant x)
+        | Nil -> Some (wrap @@ Ir.Nil)
+        | Lam {linear; parameters; result_type; body} ->
+            let (bnds, env') = add_names env fst parameters in
+            Some (
+                wrap @@  
+                    Ir.Lam {
+                        linear;
+                        parameters = List.combine bnds (List.map snd parameters);
+                        result_type;
+                        body = transform_expr env' body id
+                    })
+        | Annotate (e, ty) -> 
+            Option.map
+                (fun v -> wrap @@ Ir.VAnnotate (v, ty))
+                (transform_syntactic_value env pos e)
+        | Cons (x, xs) ->
+             Option.bind (transform_syntactic_value env pos x) (fun v ->
+             Option.bind (transform_syntactic_value env pos xs) (fun vs ->
+                 Some (wrap @@ Ir.Cons (v, vs))))
+        | Tuple xs ->
+             List.map (transform_syntactic_value env pos) xs (* list(option(value)) *)
+                |> sequence_options (* option(list(value))*)
+                |> Option.map (fun vs -> (wrap @@ Ir.Tuple vs))
+        | Inl x ->
+            Option.map
+                (fun v -> wrap @@ Ir.Inl v)
+                (transform_syntactic_value env pos x)
+        | Inr x ->
+            Option.map
+                (fun v -> wrap @@ Ir.Inr v)
+                (transform_syntactic_value env pos x)
+        | _ -> None
 (* Transforms a subterm into an IR computation, naming if necessary. *)
 and transform_subterm
     (env: env)
@@ -240,36 +291,17 @@ and transform_subterm
     (* env: current environment
        x: sugared expression
        k: continuation which takes a *value*
+       Return type is an IR computation
      *)
-    (* Return type is an IR computation *)
-    (* Call transform_expr on the sugared expression.
-       Based on the result, either call continuation if the computation is
-       trivial (i.e., Return v) -- keeping in mind Return v doesn't exist in
-       sugared AST anymore! (Var, Lam, Constant)
-     *)
-    transform_expr env x (fun env c ->
-        let pos = WithPos.pos x in
-        let wrap v = WithPos.make ~pos v in
-        match WithPos.node x with
-            (* Translate syntactic values directly to avoid a needless
-               administrative reduction.
-             *)
-            | Primitive p -> wrap (Ir.Primitive p) |> k env
-            | Atom a -> wrap (Ir.Atom a) |> k env
-            | Var var ->
-                let v = lookup_var var env pos in
-                wrap (Ir.Variable (v, None)) |> k env
-            | Constant c -> wrap (Ir.Constant c) |> k env
-            | Lam {linear; parameters; result_type; body} ->
-                let (bnds, env') = add_names env fst parameters in
-                wrap (
-                    Ir.Lam {
-                        linear;
-                        parameters = List.combine bnds (List.map snd parameters);
-                        result_type;
-                        body = transform_expr env' body id }) |> k env
-            (* Other expressions need to be bound to an intermediate variable *)
-            | _ ->
+    let pos = WithPos.pos x in
+    let wrap v = WithPos.make ~pos v in
+
+    (* If we have a syntactic value already then we can just do the direct conversion *)
+    match transform_syntactic_value env pos x with
+        | Some value -> k env value
+        | None ->
+            (* Otherwise we need to insert a binder *)
+            transform_expr env x (fun env c ->
                 (* Create a new binder *)
                 let bnd = Ir.Binder.make () in
                 (* Create a new variable from the binder *)

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -176,8 +176,8 @@ and check_val :
                 match ty with
                     | Type.Sum (t1, _) ->
                         let t1 =
-                            if Settings.(get returnable_datatypes) then
-                                Type.make_returnable ty
+                            if not @@ Settings.(get liberal_datatypes) then
+                                Type.make_returnable t1
                             else t1
                         in
                         check_val ienv decl_env v t1
@@ -188,8 +188,8 @@ and check_val :
                 match ty with
                     | Type.Sum (_, t2) ->
                         let t2 =
-                            if Settings.(get returnable_datatypes) then
-                                Type.make_returnable ty
+                            if not @@ Settings.(get liberal_datatypes) then
+                                Type.make_returnable t2
                             else t2
                         in
                         check_val ienv decl_env v (Type.make_returnable t2)
@@ -202,8 +202,8 @@ and check_val :
                             (* Check whether we can only create lists of
                                returnable elements *)
                             let () =
-                                if Settings.(get returnable_datatypes) && (not
-                                    @@ Type.is_returnable t) then
+                                if not (Settings.(get liberal_datatypes)) &&
+                                    (not @@ Type.is_returnable t) then
                                     Gripers.lists_returnable ty [pos]
                                 else ()
                             in
@@ -232,7 +232,7 @@ and check_val :
             let (check_envs, check_constrss) =
                 List.map (fun (v, ty) ->
                     let ty =
-                        if Settings.(get returnable_datatypes) then
+                        if not @@ Settings.(get liberal_datatypes) then
                             Type.make_returnable ty
                         else ty
                     in
@@ -477,7 +477,7 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
             let elem_ty =
                 match ty1 with
                     | Type.List elem_ty ->
-                        if Settings.(get returnable_datatypes) then
+                        if not @@ Settings.(get liberal_datatypes) then
                             Type.make_returnable elem_ty
                         else
                             elem_ty
@@ -630,7 +630,11 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
                 | pty -> Pretype.to_type pty
             in
             let get_check_ty pty = function
-                | Some ty -> Some ty
+                | Some ty ->
+                    if Settings.(get liberal_datatypes) then
+                        Some (Type.make_returnable ty)
+                    else
+                        Some ty
                 | None -> default_ty pty
             in
             (* Precondition: pretypes have already been filled in during pre-typing,
@@ -647,9 +651,16 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
                     let (term_env, term_constrs) =
                             check_val ienv decl_env tuple target_ty
                     in
+                    let body_env_no_binders = Ty_env.delete_many bnd_vars body_env in
                     (* Combine environments, union constraints *)
                     let (env, env_constrs) =
-                        Ty_env.combine ienv term_env body_env pos
+                        Ty_env.combine ienv term_env body_env_no_binders pos
+                    in
+                    (* Do continuation aliasing check if any component is non-returnable
+                       (e.g. if we are using liberal DTs) *)
+                    let () =
+                        if not @@ List.for_all (Type.is_returnable) check_tys then
+                            Ty_env.check_free_mailbox_variables check_tys body_env_no_binders
                     in
                     let constrs =
                         Constraint_set.union_many
@@ -665,7 +676,11 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
                     in
                     let component_tys =
                         match tuple_ty with
-                            | Type.Tuple tys -> tys
+                            | Type.Tuple tys ->
+                                if not @@ Settings.(get liberal_datatypes) then
+                                    List.map Type.make_returnable tys
+                                else
+                                    tys
                             | _ -> Gripers.expected_tuple_type tuple_ty [pos]
                     in
                     (* If any of the types are actually found in the continuation, then check subtype.
@@ -681,12 +696,15 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
                         |> List.map (fun (cty, ity) -> ty_constrs cty ity pos)
                         |> Constraint_set.union_many
                     in
-                    let () =
-                        if not (Type.is_returnable tuple_ty) then
-                            Gripers.let_not_returnable tuple_ty [pos]
-                    in
+                    let body_env_no_binders = Ty_env.delete_many bnd_vars body_env in
                     let (env, env_constrs) =
-                        Ty_env.combine ienv tuple_env body_env pos
+                        Ty_env.combine ienv tuple_env body_env_no_binders pos
+                    in
+                    (* Do continuation aliasing check if any component is non-returnable
+                       (e.g. if we are using liberal DTs) *)
+                    let () =
+                        if not @@ List.for_all (Type.is_returnable) component_tys then
+                            Ty_env.check_free_mailbox_variables component_tys body_env_no_binders
                     in
                     let constrs =
                         Constraint_set.union_many
@@ -694,7 +712,6 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
                     in
                     (env, constrs)
             in
-            let env = Ty_env.delete_many bnd_vars env in
             (env, constrs)
         | Guard { iname = None; _ } -> (* Should have been filled in by pre-typing *)
             assert false

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -476,7 +476,11 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
         | CaseL { term; ty = ty1; nil = comp1; cons = ((bnd1, bnd2), comp2) } ->
             let elem_ty =
                 match ty1 with
-                    | Type.List elem_ty -> elem_ty
+                    | Type.List elem_ty ->
+                        if Settings.(get returnable_datatypes) then
+                            Type.make_returnable elem_ty
+                        else
+                            elem_ty
                     | _ -> Gripers.expected_list_type ty1 [pos]
             in
             (* Check that scrutinee has annotated list type *)
@@ -487,9 +491,9 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
             let (comp1_env, comp1_constrs) = chk comp1 ty in
             (* Next, check that comp2 (cons case) has expected return type *)
             let (comp2_env, comp2_constrs) = chk comp2 ty in
-            (* Next, check that the inferred types in comp2_env match annotations and that
-               the cons case doesn't contain any troublesome mailbox variables that could 
-               introduce unsafe aliasing *)
+            (* Next, depending on whether we require returnable datatypes, we either check
+               to see whether the type is returnable, or we do an aliasing check similar to
+               the guards. *)
             let var1 = Var.of_binder bnd1 in
             let var2 = Var.of_binder bnd2 in 
             let comp2_env_no_binders = Ty_env.delete_many [var1; var2] comp2_env in
@@ -636,6 +640,7 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
                 List.map (uncurry get_check_ty) (List.combine ptys inferred_tys)
             in
             let env, constrs =
+                (* In this case we check consistency with the declared types. *)
                 if (List.for_all Option.is_some check_tys) then
                     let check_tys = List.map Option.get check_tys in
                     let target_ty = Type.make_tuple_type check_tys in

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -40,7 +40,6 @@ let rec synthesise_val :
             ty, Ty_env.empty, Constraint_set.empty
         (* No harm having this as a synth case as well. *)
         | Tuple vs ->
-                (* TODO: Check to see whether synthesised types are returnable *)
             let tys_envs_constrss = List.map (synthesise_val ienv decl_env) vs in
             let tys, envs, constrss = split3 tys_envs_constrss in
             let constrs = Constraint_set.union_many constrss in

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -38,7 +38,8 @@ let rec synthesise_val :
         | Primitive prim ->
             let ty = List.assoc prim Lib_types.signatures in
             ty, Ty_env.empty, Constraint_set.empty
-        (* No harm having this as a synth case as well *)
+        (* No harm having this as a synth case as well. Note that we won't
+           synthesise a returnable type so don't need to do anything special. *)
         | Tuple vs ->
             let tys_envs_constrss = List.map (synthesise_val ienv decl_env) vs in
             let tys, envs, constrss = split3 tys_envs_constrss in
@@ -174,20 +175,39 @@ and check_val :
             begin
                 match ty with
                     | Type.Sum (t1, _) ->
-                        check_val ienv decl_env v (Type.make_returnable t1)
+                        let t1 =
+                            if Settings.(get returnable_datatypes) then
+                                Type.make_returnable ty
+                            else t1
+                        in
+                        check_val ienv decl_env v t1
                     | _ -> Gripers.expected_sum_type ty [pos]
             end
         | Inr v ->
             begin
                 match ty with
                     | Type.Sum (_, t2) ->
+                        let t2 =
+                            if Settings.(get returnable_datatypes) then
+                                Type.make_returnable ty
+                            else t2
+                        in
                         check_val ienv decl_env v (Type.make_returnable t2)
                     | _ -> Gripers.expected_sum_type ty [pos]
             end
         | Nil ->
             begin
                 match ty with
-                    | Type.List _ -> Ty_env.empty, Constraint_set.empty
+                    | Type.List t ->
+                            (* Check whether we can only create lists of
+                               returnable elements *)
+                            let () =
+                                if Settings.(get returnable_datatypes) && (not
+                                    @@ Type.is_returnable t) then
+                                    Gripers.lists_returnable ty [pos]
+                                else ()
+                            in
+                            Ty_env.empty, Constraint_set.empty
                     | _ -> Gripers.expected_list_type ty [pos]
             end
         | Cons (v1, v2) ->
@@ -209,10 +229,14 @@ and check_val :
                 end
             in
             let vs_and_ts = List.combine vs ts in
-            (* Tuple component types must be returnable *)
             let (check_envs, check_constrss) =
                 List.map (fun (v, ty) ->
-                    check_val ienv decl_env v (Type.make_returnable ty)) vs_and_ts
+                    let ty =
+                        if Settings.(get returnable_datatypes) then
+                            Type.make_returnable ty
+                        else ty
+                    in
+                    check_val ienv decl_env v ty) vs_and_ts
                 |> List.split
             in
             let check_constrs = Constraint_set.union_many check_constrss in

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -38,13 +38,20 @@ let rec synthesise_val :
         | Primitive prim ->
             let ty = List.assoc prim Lib_types.signatures in
             ty, Ty_env.empty, Constraint_set.empty
-        (* No harm having this as a synth case as well. Note that we won't
-           synthesise a returnable type so don't need to do anything special. *)
+        (* No harm having this as a synth case as well. *)
         | Tuple vs ->
+                (* TODO: Check to see whether synthesised types are returnable *)
             let tys_envs_constrss = List.map (synthesise_val ienv decl_env) vs in
             let tys, envs, constrss = split3 tys_envs_constrss in
             let constrs = Constraint_set.union_many constrss in
             let env, constrs2 = Ty_env.combine_many ienv envs pos in
+            (* Ensure any synthesised types are returnable *)
+            let () =
+                if not <| Settings.(get liberal_datatypes) then
+                    List.iter (fun ty ->
+                        if not (Type.is_returnable ty) then
+                            Gripers.tuples_returnable ty [pos]) tys
+            in
             Type.Tuple tys,
                 env,
                 Constraint_set.union constrs constrs2
@@ -192,7 +199,7 @@ and check_val :
                                 Type.make_returnable t2
                             else t2
                         in
-                        check_val ienv decl_env v (Type.make_returnable t2)
+                        check_val ienv decl_env v t2
                     | _ -> Gripers.expected_sum_type ty [pos]
             end
         | Nil ->
@@ -631,7 +638,7 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
             in
             let get_check_ty pty = function
                 | Some ty ->
-                    if Settings.(get liberal_datatypes) then
+                    if not @@ Settings.(get liberal_datatypes) then
                         Some (Type.make_returnable ty)
                     else
                         Some ty

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -263,7 +263,7 @@ and synthesise_comp :
             let open Type in
             Mailbox {
                 capability = Capability.In;
-                interface; pattern = Some One;
+                interface; pattern = One;
                 (* 'New' always produces a returnable MB type *)
                 quasilinearity = Quasilinearity.Returnable;
             },
@@ -274,7 +274,7 @@ and synthesise_comp :
                 let open Type in
                 Mailbox {
                     capability = Capability.In;
-                    interface; pattern = Some One;
+                    interface; pattern = One;
                     (* 'New' always produces a returnable MB type *)
                     quasilinearity = Quasilinearity.Returnable;
                 }
@@ -332,7 +332,7 @@ and synthesise_comp :
                 Mailbox {
                     capability = Out;
                     interface = iname;
-                    pattern = Some (Message tag);
+                    pattern = (Message tag);
                     (* 'Send' gives the MB type the least specific
                        quasilinearity (Usable). It can be coerced to Returnable
                        via subtyping later if necessary, but we don't *need*
@@ -703,7 +703,7 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
             let target_ty = Mailbox {
                 capability = In;
                 interface = iname;
-                pattern = Some guards_pat;
+                pattern = guards_pat;
                 (* We can only receive on a Returnable guard (since the name
                    goes out of scope afterwards) *)
                 quasilinearity = Quasilinearity.Returnable
@@ -832,7 +832,7 @@ and check_guard :
                 let mb_pat =
                   match mb_ty with
                     | Some Mailbox {
-                        capability = Capability.In; pattern = Some pat; _ } -> pat
+                        capability = Capability.In; pattern = pat; _ } -> pat
                     | Some ty ->
                         Gripers.expected_receive_mailbox
                             (Var.of_binder mailbox_binder)
@@ -873,7 +873,7 @@ and check_guard :
                     Type.Mailbox {
                         capability = Capability.In;
                         interface = iname;
-                        pattern = Some One;
+                        pattern = One;
                         quasilinearity = Quasilinearity.Returnable;
                     }
                 in

--- a/lib/typecheck/gripers.ml
+++ b/lib/typecheck/gripers.ml
@@ -322,3 +322,12 @@ let pretype_consistency ty pty pos_list =
             Pretype.pp pty
     in
     raise (constraint_gen_error ~subsystem:Errors.GenCheck msg pos_list)
+
+let lists_returnable ty pos_list =
+    let msg =
+        Format.asprintf
+            "Lists must contain only returnable types, but type %a is not returnable."
+            Type.pp ty
+    in
+    raise (constraint_gen_error ~subsystem:Errors.GenCheck msg pos_list)
+

--- a/lib/typecheck/gripers.ml
+++ b/lib/typecheck/gripers.ml
@@ -308,7 +308,7 @@ let let_not_returnable ty pos_list =
 let duplicate_interface_receive_env var iface pos_list =
     let msg =
         Format.asprintf
-            "To prevent unsafe aliasing, no other variables of the same interface as a received variable may be present in the body of a receive guard or a case expression. However, variable %a also has interface name %s."
+            "To prevent unsafe aliasing, no other variables of the same interface as a received variable may be present in the body of a receive guard or a case expression. However, the type of variable %a also contains interface name %s."
             Ir.Var.pp_name var
             iface
     in

--- a/lib/typecheck/gripers.ml
+++ b/lib/typecheck/gripers.ml
@@ -331,3 +331,11 @@ let lists_returnable ty pos_list =
     in
     raise (constraint_gen_error ~subsystem:Errors.GenCheck msg pos_list)
 
+let tuples_returnable ty pos_list =
+    let msg =
+        Format.asprintf
+            "Tuples must contain only returnable types, but type %a is not returnable."
+            Type.pp ty
+    in
+    raise (constraint_gen_error ~subsystem:Errors.GenCheck msg pos_list)
+

--- a/lib/typecheck/ty_env.ml
+++ b/lib/typecheck/ty_env.ml
@@ -362,13 +362,25 @@ let make_unrestricted env pos =
       3. Nothing: No alias control: permissive, but unsafe.
   *)
 let check_free_mailbox_variables bound_variable_types env =
-    let mb_iface_tys =
+    let rec get_interfaces =
+        let open Type in
+        function
+        | Base _ | Fun _ -> []
+        | Tuple ts -> List.concat_map get_interfaces ts
+        | Sum (t1, t2) -> List.concat_map get_interfaces [t1; t2]
+        | List t -> get_interfaces t
+        | Mailbox { interface; _ } -> [interface]
+        | UserMailbox _ -> assert false
+    in
+    (*
         List.filter_map (fun ty ->
+
             if Type.is_mailbox_type ty then
                 Some (Type.get_interface ty)
             else None)
         bound_variable_types
     in
+    *)
     let open Settings in
     let open ReceiveTypingStrategy in
     match get receive_typing_strategy with
@@ -378,12 +390,22 @@ let check_free_mailbox_variables bound_variable_types env =
                     Gripers.unrestricted_recv_env v ty []
             ) env
         | Interface ->
+            (* Now we need to get the intersection of the interfaces in bound
+               variables and interfaces in environment
+            *)
+
+            (* All interfaces found in the variables being bound by the receive *)
+            let bv_interfaces =
+                List.concat_map get_interfaces bound_variable_types
+            in
+            (* For each binding in the env, ensure it's not also contained in BV interfaces *)
             iter (fun v ty ->
-                match ty with
-                    | Type.Mailbox { interface; _ } when (List.mem interface mb_iface_tys) ->
-                        Gripers.duplicate_interface_receive_env
-                        v interface
-                        []
-                    | _ -> ()
+                let ty_interfaces = get_interfaces ty in
+                let interfaces_in_both = ListUtils.intersect bv_interfaces ty_interfaces in
+                List.iter (fun offending_interface ->
+                    Gripers.duplicate_interface_receive_env
+                    v offending_interface
+                    []
+                ) interfaces_in_both
             ) env
         | Nothing -> ()

--- a/lib/typecheck/ty_env.ml
+++ b/lib/typecheck/ty_env.ml
@@ -29,6 +29,13 @@ let union = VarMap.union
 
 let from_list xs = List.to_seq xs |> VarMap.of_seq
 
+let dump env =
+    VarMap.bindings env
+    |> List.iter (fun (x, ty) ->
+            Format.(fprintf std_formatter "%s : %a\n%!"
+                (Ir.Var.unique_name x)
+                Type.pp ty))
+
 
 (* Joins two sequential or concurrent environments (i.e., where *both*
    actions will happen). *)
@@ -86,6 +93,10 @@ let join : Interface_env.t -> t -> t -> Position.t -> t * Constraint_set.t =
                               match Quasilinearity.sequence ql1 ql2 with
                                 | Some ql -> ql
                                 | None ->
+                                    Format.printf "Env1:\n";
+                                    dump env1;
+                                    Format.printf "Env2:\n";
+                                    dump env2;
                                     Gripers.invalid_ql_sequencing var [pos]
                           in
                           let ((cap, pat), constrs) =
@@ -319,13 +330,6 @@ let intersect : t -> t -> Position.t -> t * Constraint_set.t =
             from_list (merged @ disjoints), constrs
         in
         intersect_envs env1 env2
-
-let dump env =
-    VarMap.bindings env
-    |> List.iter (fun (x, ty) ->
-            Format.(fprintf std_formatter "%s : %a\n%!"
-                (Ir.Var.unique_name x)
-                Type.pp ty))
 
 let make_usable =
     VarMap.map Type.make_usable

--- a/lib/typecheck/ty_env.ml
+++ b/lib/typecheck/ty_env.ml
@@ -69,12 +69,12 @@ let join : Interface_env.t -> t -> t -> Position.t -> t * Constraint_set.t =
                                 (subtype ienv t2 t1 pos)
                         in
                         (Fun { linear = false; args = dom1; result = cod1 }, subty_constrs)
-                | Mailbox { pattern = None; _ }, _ | _, Mailbox { pattern = None; _ } ->
-                    assert false (* Set by pre-typing *)
+                | UserMailbox _, _ | _, UserMailbox _ ->
+                    assert false (* Should have been desugared *)
                 | Mailbox { capability = cap1; interface = iface1; pattern =
-                    Some pat1; quasilinearity = ql1 },
+                    pat1; quasilinearity = ql1 },
                   Mailbox { capability = cap2; interface = iface2; pattern =
-                      Some pat2; quasilinearity = ql2 } ->
+                      pat2; quasilinearity = ql2 } ->
                       (* We can only join variables with the same interface
                          name. If these match, we can join the types. *)
                       if iface1 <> iface2 then
@@ -94,7 +94,7 @@ let join : Interface_env.t -> t -> t -> Position.t -> t * Constraint_set.t =
                           Mailbox {
                               capability = cap;
                               interface = iface1;
-                              pattern = Some pat;
+                              pattern = pat;
                               quasilinearity = ql
                           }, constrs
                 | List ty1, List ty2 ->
@@ -220,12 +220,11 @@ let intersect : t -> t -> Position.t -> t * Constraint_set.t =
                   Fun { linear = linear2; args = dom2; result = cod2 }
                     when (linear1 = linear2) && dom1 = dom2 && cod1 = cod2 ->
                         (Fun { linear = linear1; args = dom1; result = cod1 }, Constraint_set.empty)
-                | Mailbox { pattern = None; _ }, _ | _, Mailbox { pattern = None; _ } ->
-                    assert false (* Set by pre-typing *)
+                | UserMailbox _, _ | _, UserMailbox _ -> assert false (* desugared already *)
                 | Mailbox { capability = cap1; interface = iface1; pattern =
-                    Some pat1; quasilinearity = ql1 },
+                    pat1; quasilinearity = ql1 },
                   Mailbox { capability = cap2; interface = iface2; pattern =
-                      Some pat2; quasilinearity = ql2 } ->
+                      pat2; quasilinearity = ql2 } ->
                       (* As before -- interface names must be the same*)
                       if iface1 <> iface2 then
                           Gripers.env_interface_mismatch
@@ -237,7 +236,7 @@ let intersect : t -> t -> Position.t -> t * Constraint_set.t =
                           Mailbox {
                               capability = cap;
                               interface = iface1;
-                              pattern = Some pat;
+                              pattern = pat;
                               (* Must take strongest QL across all branches. *)
                               quasilinearity = Quasilinearity.max ql1 ql2
                           }, constrs
@@ -286,9 +285,9 @@ let intersect : t -> t -> Position.t -> t * Constraint_set.t =
               in
               (* Relaxes a mailbox type from !E to !(E+1) *)
               let rec relax_send_type = function
-                | Mailbox { capability = Out; interface; quasilinearity; pattern = Some pat } ->
+                | Mailbox { capability = Out; interface; quasilinearity; pattern = pat } ->
                           let pat = Pattern.Plus (pat, Pattern.One) in
-                          Mailbox { capability = Out; interface; quasilinearity; pattern = Some pat }
+                          Mailbox { capability = Out; interface; quasilinearity; pattern = pat }
                 | List ty -> List (relax_send_type ty)
                 | _ ->
                   raise (Errors.internal_error "ty_env.ml" "error in disjoint MB combination")

--- a/lib/typecheck/type_utils.ml
+++ b/lib/typecheck/type_utils.ml
@@ -20,7 +20,7 @@ let rec make_unrestricted t pos =
         | Mailbox { capability = Capability.In; _ } ->
             Gripers.cannot_make_unrestricted t [pos]
         (* Generate a pattern constraint in order to ensure linearity *)
-        | Mailbox { capability = Capability.Out; pattern = Some pat; _ } ->
+        | Mailbox { capability = Capability.Out; pattern = pat; _ } ->
                 Constraint_set.of_list
                     [Constraint.make (Pattern.One) pat]
         | Tuple tys ->
@@ -43,6 +43,8 @@ let rec subtype_type :
         Interface_env.t -> Type.t -> Type.t -> Position.t -> Constraint_set.t =
     fun visited ienv t1 t2 pos ->
         match t1, t2 with
+            | UserMailbox _, _
+            | _, UserMailbox _ -> assert false
             | Base b1, Base b2 when b1 = b2->
                         Constraint_set.empty
 
@@ -56,10 +58,6 @@ let rec subtype_type :
                     (subtype_type visited ienv tya1 tyb1 pos)
                     (subtype_type visited ienv tya2 tyb2 pos)
             | List ty1, List ty2 -> subtype_type visited ienv ty1 ty2 pos
-            | Mailbox { pattern = None; _ }, _
-            | _, Mailbox { pattern = None; _ } ->
-                    (* Should have been sorted by annotation pass *)
-                    assert false
             | Fun { linear = lin1; args = args1;
                     result = body1 },
               Fun { linear = lin2; args = args2;
@@ -77,13 +75,13 @@ let rec subtype_type :
             | Mailbox {
                 capability = capability1;
                 interface = iname1;
-                pattern = Some pat1;
+                pattern = pat1;
                 quasilinearity = ql1
               },
               Mailbox {
                 capability = capability2;
                 interface = iname2;
-                pattern = Some pat2;
+                pattern = pat2;
                 quasilinearity = ql2
               } ->
                   (* First, ensure interface subtyping *)

--- a/lib/util/utility.ml
+++ b/lib/util/utility.ml
@@ -12,6 +12,16 @@ type stringset = StringSet.t
 
 (* Pipelining and composition *)
 
+(* Options *)
+let sequence_options xs =
+  List.fold_right
+    (fun x acc ->
+       match x, acc with
+       | Some v, Some vs -> Some (v :: vs)
+       | _ -> None)
+    xs
+    (Some [])
+
 (* Reverse function application (nicer and more uniform than `@@`) *)
 let (<|) f x = f x
 

--- a/lib/util/utility.ml
+++ b/lib/util/utility.ml
@@ -43,6 +43,9 @@ let is_uppercase c =
 
 module ListUtils = struct
 
+let intersect xs ys =
+  List.filter (fun x -> List.mem x ys) xs
+
 let rec split3 : ('a * 'b * 'c) list -> 'a list * 'b list * 'c list = function
     | [] -> ([], [], [])
     | (x, y, z) :: rest ->

--- a/test/errors/list-alias-test.pat
+++ b/test/errors/list-alias-test.pat
@@ -1,0 +1,42 @@
+interface Test { }
+interface Receiver { Enter(Test!1) }
+
+def receiver(mbList: List(Test!), self: Receiver?): Unit {
+    guard self : Enter.Enter {
+        receive Enter(mb) from self ->
+            spawn { receiver2((mb :: mbList), self) }
+    }
+}
+
+def receiver2(mbList: List(Test!), self: Receiver?): Unit {
+    guard self : Enter {
+        receive Enter(mb) from self ->
+            free(self);
+            spawn { receiver3((mb :: mbList)) }
+    }
+}
+
+def receiver3(mbList: List(Test!)): Unit {
+    caseL mbList: List(Test!) of {
+          nil -> ()
+        | (x :: xs) ->
+            caseL xs: List(Test!) of {
+                nil -> ()
+                | (y :: ys) ->
+                    # x and y are in scope here as separate names, yet
+                    # refer to the same underlying name
+                    ()
+            }
+    }
+}
+
+def main(): Unit {
+    let mb1 = new[Test] in
+    let receiverMb = new[Receiver] in
+    spawn { receiver((nil : List(Test!1)), receiverMb) };
+    receiverMb ! Enter(mb1);
+    receiverMb ! Enter(mb1);
+    free(mb1)
+}
+
+main()

--- a/test/examples/savina/barber.pat
+++ b/test/examples/savina/barber.pat
@@ -2,7 +2,6 @@ interface WaitingRoom { Enter(Customer!), Next(Barber!), Sleeping(Barber!) }
 interface WaitingRoomBuffer { WaitingCustomer(Customer!) }
 interface Customer { Start(), Full(), Wait(), Done() }
 interface Barber { Wake(WaitingRoom!), CustomerReady(Customer!, WaitingRoom!), RoomEmpty(WaitingRoom!) }
-interface SleepNotification { Sleeping(Barber!) }
 
 
 ### Waiting Room
@@ -14,7 +13,7 @@ interface SleepNotification { Sleeping(Barber!) }
 ## and any Enter requests will need to transition us back to waitingRoom
 
 
-def waitingRoom(self: WaitingRoom?, customerBuffer: WaitingRoomBuffer?(WaitingCustomer*),
+def waitingRoom(self: WaitingRoom?, customerBuffer: WaitingRoomBuffer?,
                 numCustomers: Int, capacity: Int): Unit {
     guard self : Enter* . Next {
         receive Enter(customer) from self ->

--- a/test/examples/savina/barber.pat
+++ b/test/examples/savina/barber.pat
@@ -1,0 +1,133 @@
+interface WaitingRoom { Enter(Customer!), Next(Barber!), Sleeping(Barber!) }
+interface WaitingRoomBuffer { WaitingCustomer(Customer!) }
+interface Customer { Start(), Full(), Wait(), Done() }
+interface Barber { Wake(WaitingRoom!), CustomerReady(Customer!, WaitingRoom!), RoomEmpty(WaitingRoom!) }
+interface SleepNotification { Sleeping(Barber!) }
+
+
+### Waiting Room
+
+## In the case that the barber is busy, we are waiting for a Next message,
+## and our mailbox can contain many Enter messages and customer messages
+
+## In the case that the barber is asleep, there won't be any waiting customers,
+## and any Enter requests will need to transition us back to waitingRoom
+
+
+def waitingRoom(self: WaitingRoom?, customerBuffer: WaitingRoomBuffer?(WaitingCustomer*),
+                numCustomers: Int, capacity: Int): Unit {
+    guard self : Enter* . Next {
+        receive Enter(customer) from self ->
+            if (numCustomers >= capacity) {
+                print("Waiting room full; kicking customer out");
+                customer ! Full();
+                waitingRoom(self, customerBuffer, numCustomers, capacity)
+            } else {
+                customerBuffer ! WaitingCustomer(customer);
+                customer ! Wait();
+                waitingRoom(self, customerBuffer, numCustomers + 1, capacity)
+            }
+        receive Next(barber) from self ->
+            # Receive from customer buffer
+            print("Sending next customer to barber");
+            guard customerBuffer : WaitingCustomer* {
+                free ->
+                    # In this case there are no more customers.
+                    # Notify the barber that he can sleep; move to sleeping state
+                    barber ! RoomEmpty(self);
+                    guard self : Enter* . Sleeping {
+                        # Receive notification that barber is asleep
+                        receive Sleeping(barber) from self ->
+                            waitingRoomSleepingBarber(self, barber, capacity)
+                    }
+                receive WaitingCustomer(customer) from customerBuffer ->
+                    barber ! CustomerReady(customer, self);
+                    waitingRoom(self, customerBuffer, numCustomers - 1, capacity)
+            }
+    }
+}
+
+
+# Called when the barber is snoozing (i.e., numWaiting = 0)
+def waitingRoomSleepingBarber(self: WaitingRoom?, barber: Barber!, capacity: Int): Unit {
+    guard self : Enter* {
+        free -> ()
+        receive Enter(customer) from self ->
+            let buffer = new[WaitingRoomBuffer] in
+            buffer ! WaitingCustomer(customer);
+            customer ! Wait();
+            barber ! Wake(self);
+            waitingRoom(self, buffer, 1, capacity)
+    }
+}
+
+
+### Barber
+
+def barber(self: Barber?): Unit {
+    guard self : CustomerReady + RoomEmpty {
+        receive RoomEmpty(waitingRoom) from self ->
+            print("Room empty; going to sleep");
+            waitingRoom ! Sleeping(self);
+            sleepingBarber(self)
+        receive CustomerReady(customer, waitingRoom) from self ->
+            customer ! Start();
+            print("Cutting hair");
+            print("Finished cutting hair; notifying customer and waiting room");
+            customer ! Done();
+            waitingRoom ! Next(self);
+            barber(self)
+    }
+}
+
+def sleepingBarber(self: Barber?): Unit {
+    guard self : Wake + 1 {
+        free -> ()
+        receive Wake(waitingRoom) from self ->
+            waitingRoom ! Next(self);
+            barber(self)
+    }
+}
+
+
+### Customer
+def customer(self: Customer?, waitingRoom: WaitingRoom!): Unit {
+    waitingRoom ! Enter(self);
+    guard self : Full + (Wait.Start.Done) {
+        receive Full() from self ->
+            print("Room is full. Oh well, best go somewhere else");
+            free(self)
+        receive Wait() from self ->
+            print("Waiting");
+            waitingCustomer(self)
+    }
+}
+
+def waitingCustomer(self: Customer?): Unit {
+    guard self : Start.Done {
+        receive Start() from self ->
+            print("Barber is starting my haircut");
+            guard self : Done {
+                receive Done() from self ->
+                    print("Haircut finished!");
+                    free(self)
+            }
+    }
+}
+
+
+### Main
+
+def main(): Unit {
+    let cust1 = new[Customer] in
+    let cust2 = new[Customer] in
+    let cust3 = new[Customer] in
+    let waitingRoom = new[WaitingRoom] in
+    let barber = new[Barber] in
+    spawn { waitingRoomSleepingBarber(waitingRoom, barber, 10) };
+    spawn { sleepingBarber(barber) };
+    spawn { customer(cust1, waitingRoom) };
+    spawn { customer(cust2, waitingRoom) };
+    spawn { customer(cust3, waitingRoom) }
+}
+

--- a/test/examples/savina/barber2.pat
+++ b/test/examples/savina/barber2.pat
@@ -1,0 +1,139 @@
+interface WaitingRoom { Enter(Customer!), Next(Barber!), Sleeping(Barber!), WaitingCustomer(Customer!) }
+interface Customer { Start(), Full(), NoWait(), Wait(), Done() }
+interface Barber { Wake(WaitingRoom!), CustomerReady(Customer!, WaitingRoom!),
+    RoomEmpty(WaitingRoom!), Exit() }
+
+
+### Waiting Room
+
+## In the case that the barber is busy, we are waiting for a Next message,
+## and our mailbox can contain many Enter messages and customer messages
+
+## In the case that the barber is asleep, there won't be any waiting customers,
+## and any Enter requests will need to transition us back to waitingRoom
+
+
+def waitingRoom(self: WaitingRoom?, numCustomers: Int, capacity: Int): Unit {
+    guard self : Enter* . WaitingCustomer* . Next {
+        receive Enter(customer) from self ->
+            if (numCustomers >= capacity) {
+                print("Waiting room full; kicking customer out");
+                customer ! Full();
+                waitingRoom(self, numCustomers, capacity)
+            } else {
+                customer ! Wait();
+                self ! WaitingCustomer(customer);
+                waitingRoom(self, numCustomers + 1, capacity)
+            }
+        receive Next(barber) from self ->
+            if (numCustomers > 0) {
+                    guard self : Enter* . WaitingCustomer* {
+                        free -> barber ! Exit()
+                        receive WaitingCustomer(customer) from self ->
+                            barber ! CustomerReady(customer, self);
+                            waitingRoom(self, numCustomers - 1, capacity)
+                        receive Enter(customer) from self ->
+                            customer ! NoWait();
+                            barber ! CustomerReady(customer, self);
+                            waitingRoom(self, numCustomers, capacity)
+                    }
+                } else {
+                    barber ! RoomEmpty(self);
+                    guard self : Enter* . WaitingCustomer* . Sleeping {
+                        receive Sleeping(barber) from self ->
+                            waitingRoomSleepingBarber(self, barber, capacity)
+                    }
+            }
+    }
+}
+
+# Called when the barber is snoozing (i.e., numWaiting = 0)
+def waitingRoomSleepingBarber(self: WaitingRoom?, barber: Barber!, capacity: Int): Unit {
+    guard self : Enter* . WaitingCustomer* {
+        free -> ()
+        receive WaitingCustomer(customer) from self ->
+                self ! WaitingCustomer(customer);
+                barber ! Wake(self);
+                waitingRoom(self, 1, capacity)
+        receive Enter(customer) from self ->
+                self ! WaitingCustomer(customer);
+                customer ! Wait();
+                barber ! Wake(self);
+                waitingRoom(self, 1, capacity)
+    }
+}
+
+
+### Barber
+
+def awakeBarber(self: Barber?): Unit {
+    guard self : CustomerReady + RoomEmpty + Exit {
+        receive Exit() from self -> free(self)
+        receive RoomEmpty(waitingRoom) from self ->
+            print("Room empty; going to sleep");
+            waitingRoom ! Sleeping(self);
+            sleepingBarber(self)
+        receive CustomerReady(customer, waitingRoom) from self ->
+            customer ! Start();
+            print("Cutting hair");
+            print("Finished cutting hair; notifying customer and waiting room");
+            customer ! Done();
+            waitingRoom ! Next(self);
+            awakeBarber(self)
+    }
+}
+
+def sleepingBarber(self: Barber?): Unit {
+    guard self : Wake + 1 {
+        free -> ()
+        receive Wake(waitingRoom) from self ->
+            waitingRoom ! Next(self);
+            awakeBarber(self)
+    }
+}
+
+
+### Customer
+def customer(self: Customer?, waitingRoom: WaitingRoom!): Unit {
+    waitingRoom ! Enter(self);
+    guard self : Full + (NoWait.Start.Done) + (Wait.Start.Done) {
+        receive Full() from self ->
+            print("Room is full. Oh well, best go somewhere else");
+            free(self)
+        receive Wait() from self ->
+            print("Waiting");
+            waitingCustomer(self)
+        receive NoWait() from self ->
+            print("No need to wait; going to barber");
+            waitingCustomer(self)
+    }
+}
+
+def waitingCustomer(self: Customer?): Unit {
+    guard self : Start.Done {
+        receive Start() from self ->
+            print("Barber is starting my haircut");
+            guard self : Done {
+                receive Done() from self ->
+                    print("Haircut finished!");
+                    free(self)
+            }
+    }
+}
+
+
+### Main
+
+def main(): Unit {
+    let cust1 = new[Customer] in
+    let cust2 = new[Customer] in
+    let cust3 = new[Customer] in
+    let waitingRoom = new[WaitingRoom] in
+    let barber = new[Barber] in
+    spawn { waitingRoomSleepingBarber(waitingRoom, barber, 10) };
+    spawn { sleepingBarber(barber) };
+    spawn { customer(cust1, waitingRoom) };
+    spawn { customer(cust2, waitingRoom) };
+    spawn { customer(cust3, waitingRoom) }
+}
+

--- a/test/examples/savina/barber3.pat
+++ b/test/examples/savina/barber3.pat
@@ -1,6 +1,6 @@
 interface WaitingRoom { Enter(Customer!), Next(Barber!), Sleeping(Barber!),
-    WaitingCustomer(Customer!) }
-interface Customer { Start(), Full(), NoWait(), Wait(), Done() }
+    WaitingCustomer(Customer!), PendingCustomer(Customer!) }
+interface Customer { Start(), Full(), Wait(), Done() }
 interface Barber { Wake(WaitingRoom!), CustomerReady(Customer!, WaitingRoom!),
     RoomEmpty(WaitingRoom!), Exit() }
 
@@ -12,6 +12,18 @@ interface Barber { Wake(WaitingRoom!), CustomerReady(Customer!, WaitingRoom!),
 
 ## In the case that the barber is asleep, there won't be any waiting customers,
 ## and any Enter requests will need to transition us back to waitingRoom
+
+## NOTE: This will only work with Erlang-style semantics for pattern matching
+## (which would be sensible but isn't the current Pat semantics).
+##
+## We shouldn't be relying on numCustomers for actually making deisions in
+## Next(-) -- no way of tracking the dependency between buffer size and
+## numCustomers.
+##
+## In this case we assume we try and consume Enter and WaitingCustomer messages
+## prior to Next messages. The only time we should process a Next message in
+## this state is if all Enter and WaitingCustomer requests have already been
+## processed.
 def waitingRoom(self: WaitingRoom?, numCustomers: Int, capacity: Int): Unit {
     guard self : Enter* . WaitingCustomer* . Next {
         receive Enter(customer) from self ->
@@ -24,28 +36,40 @@ def waitingRoom(self: WaitingRoom?, numCustomers: Int, capacity: Int): Unit {
                 self ! WaitingCustomer(customer);
                 waitingRoom(self, numCustomers + 1, capacity)
             }
+        receive WaitingCustomer(customer) from self ->
+            self ! PendingCustomer(customer);
+            waitingRoomPending(self, numCustomers, capacity)
         receive Next(barber) from self ->
-            if (numCustomers > 0) {
-                guard self : Enter* . WaitingCustomer* {
-                    free -> barber ! Exit()
-                    receive WaitingCustomer(customer) from self ->
-                        barber ! CustomerReady(customer, self);
-                        waitingRoom(self, numCustomers - 1, capacity)
-                    # Customer has just entered
-                    receive Enter(customer) from self ->
-                        customer ! NoWait();
-                        barber ! CustomerReady(customer, self);
-                        waitingRoom(self, numCustomers, capacity)
-                }
-            } else {
-                barber ! RoomEmpty(self);
-                guard self : Enter* . WaitingCustomer* . Sleeping {
-                    receive Sleeping(barber) from self ->
-                        waitingRoomSleepingBarber(self, barber, capacity)
-                }
+            barber ! RoomEmpty(self);
+            guard self : Enter* . WaitingCustomer* . Sleeping {
+                receive Sleeping(barber) from self ->
+                    waitingRoomSleepingBarber(self, barber, capacity)
             }
     }
 }
+
+def waitingRoomPending(self: WaitingRoom?, numCustomers: Int, capacity: Int): Unit {
+    guard self : PendingCustomer . Next . (Enter* . WaitingCustomer*)  {
+        receive Enter(customer) from self ->
+            if (numCustomers >= capacity) {
+                print("Waiting room full; kicking customer out");
+                customer ! Full();
+                waitingRoomPending(self, numCustomers, capacity)
+            } else {
+                customer ! Wait();
+                self ! WaitingCustomer(customer);
+                waitingRoomPending(self, numCustomers + 1, capacity)
+            }
+        receive Next(barber) from self ->
+            guard self : PendingCustomer . Enter* . WaitingCustomer* {
+                free -> barber ! Exit()
+                receive PendingCustomer(customer) from self ->
+                    barber ! CustomerReady(customer, self);
+                    waitingRoom(self, numCustomers - 1, capacity)
+            }
+    }
+}
+
 
 # Called when the barber is snoozing (i.e., numWaiting = 0)
 def waitingRoomSleepingBarber(self: WaitingRoom?, barber: Barber!, capacity: Int): Unit {
@@ -96,15 +120,12 @@ def sleepingBarber(self: Barber?): Unit {
 ### Customer
 def customer(self: Customer?, waitingRoom: WaitingRoom!): Unit {
     waitingRoom ! Enter(self);
-    guard self : Full + (NoWait.Start.Done) + (Wait.Start.Done) {
+    guard self : Full + (Wait.Start.Done) {
         receive Full() from self ->
             print("Room is full. Oh well, best go somewhere else");
             free(self)
         receive Wait() from self ->
             print("Waiting");
-            waitingCustomer(self)
-        receive NoWait() from self ->
-            print("No need to wait; going to barber");
             waitingCustomer(self)
     }
 }

--- a/test/examples/savina/lists/banking.pat
+++ b/test/examples/savina/lists/banking.pat
@@ -17,7 +17,7 @@ interface AccountMb {
   Stop()
 }
 
-def spawnAccounts(self: TellerMb?, numsAccounts: List(Int), soFar: Int, acc: List(AccountMb!)) : (TellerMb? * List(AccountMb!)) {
+def spawnAccounts(self: TellerMb?, numsAccounts: List(Int), soFar: Int, acc: List(AccountMb!)) : (TellerMb? * List(AccountMb![R])) {
   caseL numsAccounts : List(Int) of {
     nil -> (self, acc)
     | (n :: ns) ->

--- a/test/examples/savina/lists/banking.pat
+++ b/test/examples/savina/lists/banking.pat
@@ -17,13 +17,13 @@ interface AccountMb {
   Stop()
 }
 
-def spawnAccounts(self: TellerMb?, numsAccounts: List(Int), soFar: Int, acc: List(AccountMb!)) : (TellerMb? * List(AccountMb![R])) {
+def spawnAccounts(numsAccounts: List(Int), soFar: Int, acc: List(AccountMb!)) : List(AccountMb!) {
   caseL numsAccounts : List(Int) of {
-    nil -> (self, acc)
+    nil -> acc
     | (n :: ns) ->
         let accountMb = new [AccountMb] in
         spawn { account(accountMb, soFar, n)};
-        spawnAccounts(self, ns, soFar + 1, (accountMb :: acc))
+        spawnAccounts(ns, soFar + 1, (accountMb :: acc))
     }
   }
 
@@ -31,7 +31,7 @@ def spawnAccounts(self: TellerMb?, numsAccounts: List(Int), soFar: Int, acc: Lis
 ## main loop.
 def teller(self: TellerMb?, numAccounts : Int, numsAccounts: List(Int)): Unit {
 
-  let (self, accountMbs) = spawnAccounts(self, numsAccounts, 1, (nil : List(AccountMb!))) in
+  let accountMbs = spawnAccounts(numsAccounts, 1, (nil : List(AccountMb!))) in
 
   guard self: Start {
     receive Start() from self ->
@@ -47,7 +47,7 @@ def teller(self: TellerMb?, numAccounts : Int, numsAccounts: List(Int)): Unit {
 }
 
 ## Randomly chooses the source account.
-def generate_work(tellerMb: TellerMb!, numAccounts: Int, accs : List(AccountMb![R])): Unit {
+def generate_work(tellerMb: TellerMb!, numAccounts: Int, accs : List(AccountMb!)): Unit {
 
   # Randomly choose source account from which the funds shall be taken.
   let sourceId = rand(numAccounts - 1) in # -1 because rand() is 0-indexed.
@@ -103,7 +103,7 @@ def choose_dst_acc(tellerMb: TellerMb!, numAccounts: Int, srcAccount: (Unit + Ac
 }
 
 ## Teller process main loop handling replies from accounts.
-def teller_loop(self: TellerMb?, accountMbs : List(AccountMb![R])): Unit {
+def teller_loop(self: TellerMb?, accountMbs : List(AccountMb!)): Unit {
   guard self: Reply* {
     free ->
       # All credit requests serviced. Stop accounts.

--- a/test/examples/savina/lists/banking.pat
+++ b/test/examples/savina/lists/banking.pat
@@ -103,7 +103,7 @@ def choose_dst_acc(tellerMb: TellerMb!, numAccounts: Int, srcAccount: (Unit + Ac
 }
 
 ## Teller process main loop handling replies from accounts.
-def teller_loop(self: TellerMb?, accountMbs : List(AccountMb!)): Unit {
+def teller_loop(self: TellerMb?, accountMbs : List(AccountMb![R])): Unit {
   guard self: Reply* {
     free ->
       # All credit requests serviced. Stop accounts.

--- a/test/examples/savina/lists/barber.pat
+++ b/test/examples/savina/lists/barber.pat
@@ -36,11 +36,11 @@ def room(self: RoomMb?, capacity: Int, waiters: List(CustomerMb!), waiting: Int,
         receive Enter(customerMb) from self ->
             if (waiting == capacity) {
                 customerMb ! Full(self);
-                room(self, capacity, waiters, waiting, barber)
+                spawn { room(self, capacity, waiters, waiting, barber) }
             }
             else {
                 sleep(5);
-                room(self, capacity, (customerMb :: waiters), (waiting + 1), barber)
+                spawn { room(self, capacity, (customerMb :: waiters), (waiting + 1), barber) }
             }
         receive Next() from self ->
             caseL waiters : List(CustomerMb!) of {

--- a/test/examples/savina/lists/barber.pat
+++ b/test/examples/savina/lists/barber.pat
@@ -36,7 +36,7 @@ def room(self: RoomMb?, capacity: Int, waiters: List(CustomerMb!), waiting: Int,
         receive Enter(customerMb) from self ->
             if (waiting == capacity) {
                 customerMb ! Full(self);
-                spawn { room(self, capacity, waiters, waiting, barber) }
+                room(self, capacity, waiters, waiting, barber)
             }
             else {
                 sleep(5);

--- a/test/examples/savina/lists/big.pat
+++ b/test/examples/savina/lists/big.pat
@@ -107,7 +107,7 @@ def send_ping(id: Int, actorMb1: ActorMb!, actorMb2: ActorMb!): Unit {
 def sink(self: SinkMb?): Unit {
   guard self: Actors . (Done*) {
     receive Actors(exitMbs) from self ->
-      sink_loop(self, exitMbs)
+      spawn { sink_loop(self, exitMbs) }
   }
 }
 

--- a/test/examples/savina/lists/big.pat
+++ b/test/examples/savina/lists/big.pat
@@ -92,34 +92,23 @@ def send_pong(id: Int, pingerId: Int, actorMb1: ActorMb!, actorMb2: ActorMb!): U
 
 ## Randomly issues a ping message to one of the participating actors.
 def send_ping(id: Int, actorMb1: ActorMb!, actorMb2: ActorMb!): Unit {
-
   let pongerId = rand(2) in
-
   if (pongerId == 1) {
     actorMb1 ! Ping(id)
-  }
-  else {
+  } else {
     actorMb2 ! Ping(id)
   }
 }
 
 ## Sink process that coordinates actor termination.
-def sink(self: SinkMb?): Unit {
-  guard self: Actors . (Done*) {
-    receive Actors(exitMbs) from self ->
-      spawn { sink_loop(self, exitMbs) }
-  }
-}
-
-## Sink process main loop issuing termination messages.
-def sink_loop(self: SinkMb?, exitMbs : List(ExitMb!)): Unit {
+def sink(self: SinkMb?, exitMbs : List(ExitMb!)): Unit {
   guard self: Done* {
     free ->
       # Notify all actors. Placing the sends in this clause ensures that
       # each actor is notified once.
       notifyExits(exitMbs)
     receive Done() from self ->
-        sink_loop(self, exitMbs)
+        sink(self, exitMbs)
   }
 }
 
@@ -137,7 +126,6 @@ def notifyExits(exitMbs : List(ExitMb!)): Unit {
 def main(): Unit {
 
   let sinkMb = new [SinkMb] in
-  spawn { sink(sinkMb) };
 
   let actorMb1 = new [ActorMb] in # actorMb1: ?1
   let actorMb2 = new [ActorMb] in # actorMb2: ?1
@@ -150,7 +138,8 @@ def main(): Unit {
   spawn { actor(actorMb2, exitMb2, 2, sinkMb) };
   spawn { actor(actorMb3, exitMb3, 3, sinkMb) };
 
-  let xs = (exitMb1 :: (exitMb2 :: (exitMb3 :: (nil : List(ExitMb!))))) in sinkMb ! Actors(xs);
+  let xs = (exitMb1 :: (exitMb2 :: (exitMb3 :: (nil : List(ExitMb!))))) in
+  spawn { sink(sinkMb, xs) };
 
   actorMb1 ! Neighbors(actorMb2, actorMb3); # actorMb1: ?Neighbors
   actorMb2 ! Neighbors(actorMb1, actorMb3); # actorMb2: ?Neighbors

--- a/test/examples/savina/lists/big.pat
+++ b/test/examples/savina/lists/big.pat
@@ -150,7 +150,7 @@ def main(): Unit {
   spawn { actor(actorMb2, exitMb2, 2, sinkMb) };
   spawn { actor(actorMb3, exitMb3, 3, sinkMb) };
 
-  let xs = (exitMb1 :: (exitMb2 :: (exitMb3 :: (nil : List(ExitMb![R]))))) in sinkMb ! Actors(xs);
+  let xs = (exitMb1 :: (exitMb2 :: (exitMb3 :: (nil : List(ExitMb!))))) in sinkMb ! Actors(xs);
 
   actorMb1 ! Neighbors(actorMb2, actorMb3); # actorMb1: ?Neighbors
   actorMb2 ! Neighbors(actorMb1, actorMb3); # actorMb2: ?Neighbors

--- a/test/examples/savina/lists/big.pat
+++ b/test/examples/savina/lists/big.pat
@@ -150,7 +150,7 @@ def main(): Unit {
   spawn { actor(actorMb2, exitMb2, 2, sinkMb) };
   spawn { actor(actorMb3, exitMb3, 3, sinkMb) };
 
-  let xs = (exitMb1 :: (exitMb2 :: (exitMb3 :: (nil : List(ExitMb!))))) in sinkMb ! Actors(xs);
+  let xs = (exitMb1 :: (exitMb2 :: (exitMb3 :: (nil : List(ExitMb![R]))))) in sinkMb ! Actors(xs);
 
   actorMb1 ! Neighbors(actorMb2, actorMb3); # actorMb1: ?Neighbors
   actorMb2 ! Neighbors(actorMb1, actorMb3); # actorMb2: ?Neighbors

--- a/test/examples/savina/lists/kfork.pat
+++ b/test/examples/savina/lists/kfork.pat
@@ -40,7 +40,7 @@ def flood(numMessages: Int, actorMb: ActorMb!): Unit {
   }
 }
 
-def spawnActors(numActors: Int, acc: List(ActorMb![R])): List(ActorMb![R]) {
+def spawnActors(numActors: Int, acc: List(ActorMb!)): List(ActorMb!) {
     if (numActors <= 0) {
         acc
     } else {
@@ -50,8 +50,8 @@ def spawnActors(numActors: Int, acc: List(ActorMb![R])): List(ActorMb![R]) {
     }
 }
 
-def floodActors(numMessages: Int, actorMbs: List(ActorMb![R])): Unit {
-    caseL actorMbs : List(ActorMb![R]) of {
+def floodActors(numMessages: Int, actorMbs: List(ActorMb!)): Unit {
+    caseL actorMbs : List(ActorMb!) of {
         nil -> ()
       | (a :: as) ->
             flood(numMessages, a);
@@ -62,7 +62,7 @@ def floodActors(numMessages: Int, actorMbs: List(ActorMb![R])): Unit {
 ## Launcher.
 def main(numActors: Int): Unit {
 
-  let actorMbs = spawnActors(numActors, (nil : List(ActorMb![R]))) in
+  let actorMbs = spawnActors(numActors, (nil : List(ActorMb!))) in
   floodActors(1000, actorMbs)
 }
 

--- a/test/examples/savina/lists/kfork.pat
+++ b/test/examples/savina/lists/kfork.pat
@@ -40,7 +40,7 @@ def flood(numMessages: Int, actorMb: ActorMb!): Unit {
   }
 }
 
-def spawnActors(numActors: Int, acc: List(ActorMb!)): List(ActorMb!) {
+def spawnActors(numActors: Int, acc: List(ActorMb![R])): List(ActorMb![R]) {
     if (numActors <= 0) {
         acc
     } else {
@@ -50,8 +50,8 @@ def spawnActors(numActors: Int, acc: List(ActorMb!)): List(ActorMb!) {
     }
 }
 
-def floodActors(numMessages: Int, actorMbs: List(ActorMb!)): Unit {
-    caseL actorMbs : List(ActorMb!) of {
+def floodActors(numMessages: Int, actorMbs: List(ActorMb![R])): Unit {
+    caseL actorMbs : List(ActorMb![R]) of {
         nil -> ()
       | (a :: as) ->
             flood(numMessages, a);
@@ -62,8 +62,8 @@ def floodActors(numMessages: Int, actorMbs: List(ActorMb!)): Unit {
 ## Launcher.
 def main(numActors: Int): Unit {
 
-  let actorMbs = spawnActors(numActors, (nil : List(ActorMb!))) in
-    floodActors(1000, actorMbs)
+  let actorMbs = spawnActors(numActors, (nil : List(ActorMb![R]))) in
+  floodActors(1000, actorMbs)
 }
 
 main(3)

--- a/test/tests.json
+++ b/test/tests.json
@@ -148,7 +148,9 @@
                 {"name": "Philosopher", "filename": "examples/savina/philosopher.pat", "exit_code": 0},
                 {"name": "Ping Pong", "filename": "examples/savina/ping_pong.pat", "exit_code": 0},
                 {"name": "Ping Pong (Strict)", "filename": "examples/savina/ping_pong_strict.pat", "exit_code": 0},
-                {"name": "Sleeping Barber", "filename": "examples/savina/barber.pat", "exit_code": 0},
+                {"name": "Sleeping Barber (Variation 1)", "filename": "examples/savina/barber.pat", "exit_code": 0},
+                {"name": "Sleeping Barber (Variation 2)", "filename": "examples/savina/barber2.pat", "exit_code": 0},
+                {"name": "Sleeping Barber (Variation 3)", "filename": "examples/savina/barber3.pat", "exit_code": 0},
                 {"name": "Thread Ring", "filename": "examples/savina/thread_ring.pat", "exit_code": 0}
             ]
         },

--- a/test/tests.json
+++ b/test/tests.json
@@ -148,6 +148,7 @@
                 {"name": "Philosopher", "filename": "examples/savina/philosopher.pat", "exit_code": 0},
                 {"name": "Ping Pong", "filename": "examples/savina/ping_pong.pat", "exit_code": 0},
                 {"name": "Ping Pong (Strict)", "filename": "examples/savina/ping_pong_strict.pat", "exit_code": 0},
+                {"name": "Sleeping Barber", "filename": "examples/savina/barber.pat", "exit_code": 0},
                 {"name": "Thread Ring", "filename": "examples/savina/thread_ring.pat", "exit_code": 0}
             ]
         },
@@ -157,8 +158,7 @@
                 {"name": "Banking (lists)", "filename": "examples/savina/lists/banking.pat", "exit_code": 0},
                 {"name": "Big (lists)", "filename": "examples/savina/lists/big.pat", "exit_code": 0},
                 {"name": "Cigarette Smoker (lists)", "filename": "examples/savina/lists/cig_smok.pat", "exit_code": 0},
-                {"name": "kfork (lists)", "filename": "examples/savina/lists/kfork.pat", "exit_code": 0},
-                {"name": "Sleeping Barber", "filename": "examples/savina/lists/barber.pat", "exit_code": 0}
+                {"name": "kfork (lists)", "filename": "examples/savina/lists/kfork.pat", "exit_code": 0}
             ]
         },
         { "group": "Correct examples (Others)",
@@ -210,6 +210,11 @@
                 {
                     "name": "Use after free (lists)",
                     "filename": "errors/uaf_lists.pat",
+                    "exit_code": 1
+                },
+                {
+                    "name": "Aliasing through communication (lists)",
+                    "filename": "errors/list-alias-test.pat",
                     "exit_code": 1
                 },
                 {"name": "Insufficient type information", "filename": "errors/pat_constr.pat", "exit_code": 1},

--- a/test/tests.json
+++ b/test/tests.json
@@ -166,7 +166,7 @@
             [
                 {"name": "n-Robots", "filename": "examples/robotsn.pat", "exit_code": 0},
                 {"name": "n-Robots (lists)", "filename": "examples/robotsn-lists.pat", "exit_code": 0},
-                {"name": "Guard annotation is a subpattern", "filename": "examples/pat_constr.pat", "exit_code": 0}
+                {"name": "Guard annotation is a subpattern", "filename": "examples/pat_constr.pat", "exit_code": 0},
                 {"name": "Two factor (subprocess)", "filename": "examples/two_factor.pat", "exit_code": 0},
                 {"name": "Two factor (monolithic)", "filename": "examples/two_factor_two.pat", "exit_code": 0}
             ]


### PR DESCRIPTION
- Require use of datatypes containing only returnable data by default; more liberal extension enabled through -dt / --liberal-datatypes flag
- Reduce need for quasilinearity annotations on datatypes
- Fix various examples to avoid need for more liberal datatypes extension
- Fix lists (and other DTs) admitting potential aliasing when using interface alias detection mode
- Minor structural fix to include `UserMailbox` (i.e. sugared mailbox parsed in by user that might omit the mailbox pattern annotation), and require `Mailbox` type to have a fully-defined annotation. Default quasilinearity annotations are now put in during annotation pass rather than parsing
- Minor fix to sugar_to_ir to avoid losing type information
- Fix --show-ir flag
- Three new implementations of Sleeping Barber