### PR TITLE
Postfix pretty-printing of mailbox pattern replication

### DIFF
--- a/lib/common/type.ml
+++ b/lib/common/type.ml
@@ -244,7 +244,7 @@ module Pattern = struct
         | Concat (p1, p2) ->
             fprintf ppf "(%a . %a)" pp p1 pp p2
         | Many p ->
-            fprintf ppf "*(%a)" pp p
+            fprintf ppf "(%a)*" pp p
 
     let show = Format.asprintf "%a" pp
 end


### PR DESCRIPTION
In 7c9dc98 we changed pattern replication to be postfix (i.e., `E*` rather than `*E`).
This small patch ensures that the type pretty printer correctly prints replication as postfix as well.