### PR TITLE
Add test files for tail calls / non-tail-calls

### DIFF
--- a/test/pat-tests/non-tail-call.pat
+++ b/test/pat-tests/non-tail-call.pat
@@ -1,0 +1,9 @@
+def tcSum(n: Int): Int {
+    if (n == 0) {
+        0
+    } else {
+        n + tcSum(n - 1)
+    }
+}
+
+print(intToString(tcSum(999999)))

--- a/test/pat-tests/tail-call.pat
+++ b/test/pat-tests/tail-call.pat
@@ -1,0 +1,9 @@
+def tcSum(n: Int, tot: Int): Int {
+    if (n == 0) {
+        tot
+    } else {
+        tcSum(n - 1, n + tot)
+    }
+}
+
+print(intToString(tcSum(999999, 0)))


### PR DESCRIPTION
When investigating #40 (which turned out not to need anything special) I made two test files (one with tail-call and one without). Both give the same answer, but the non-TCO version churns through a lot of memory to get there. Worth keeping them even if the interpreter didn't need to change!