### PR TITLE
Allow datatypes / case matching to be evaluated

### DIFF
--- a/lib/common/ir.ml
+++ b/lib/common/ir.ml
@@ -231,21 +231,6 @@ and guard_node =
             "RuntimeName.map"; "Interface.map"; "Var.map"; "WithIrMetadata.map"];
         data = false }]
 
-let insert_dup (dups : (Var.t * int) list) (comp : comp) : comp =
-    if List.is_empty dups then
-        comp
-    else
-        let fvs = WithIrMetadata.fvs comp in
-        WithIrMetadata.make ~fvs (Seq (WithIrMetadata.make ~fvs (Dup dups), comp))
-
-let insert_drop ?(names = []) (drops : (Var.t * int) list) (comp : comp) : comp =
-    if List.is_empty drops && List.is_empty names then
-        comp
-    else
-        let fvs = WithIrMetadata.fvs comp in
-        WithIrMetadata.make ~fvs (Seq (WithIrMetadata.make ~fvs (Drop { vars = drops; names }), comp))
-
-
 let normalise_seq comp =
     let right_nest_seq c =
         let rec mk_right_nested left right =

--- a/lib/common/ir.ml
+++ b/lib/common/ir.ml
@@ -182,11 +182,11 @@ and comp_node =
         guards: guard list;
         iname: string option
       }
-        (* Reference counting instructions inserted after typechecking *)
-        | Drop of {
-                vars: ((Var.t[@name "var"]) * int) list;
-                names: ((RuntimeName.t[@name "runtime_name"]) * int) list
-            }
+    (* Reference counting instructions inserted after typechecking *)
+    | Drop of {
+            vars: ((Var.t[@name "var"]) * int) list;
+            names: ((RuntimeName.t[@name "runtime_name"]) * int) list
+        }
     | Dup of ((Var.t[@name "var"]) * int) list
 and value = (value_node WithIrMetadata.t [@name "withIR"])
 and lambda = {

--- a/lib/common/ir.ml
+++ b/lib/common/ir.ml
@@ -182,12 +182,6 @@ and comp_node =
         guards: guard list;
         iname: string option
       }
-    (* Reference counting instructions inserted after typechecking *)
-    | Drop of {
-            vars: ((Var.t[@name "var"]) * int) list;
-            names: ((RuntimeName.t[@name "runtime_name"]) * int) list
-        }
-    | Dup of ((Var.t[@name "var"]) * int) list
 and value = (value_node WithIrMetadata.t [@name "withIR"])
 and lambda = {
     linear: bool;
@@ -364,26 +358,6 @@ and pp_comp ppf comp_with_pos =
             pp_value target
             Type.Pattern.pp pattern
             (pp_print_newline_list pp_guard) guards
-    | Drop { vars; names } ->
-        let pp_var ppf (var, count) = fprintf ppf "\"%s\":%d" (Var.unique_name var) count in
-        let pp_name ppf (name, count) = fprintf ppf "\"%a\":%d" RuntimeName.pp name count in
-        begin
-            match (vars, names) with
-            | (_, []) ->
-                fprintf ppf "drop (%a)"
-                    (pp_print_comma_list pp_var) vars
-            | ([], _) ->
-                fprintf ppf "drop_names (%a)"
-                    (pp_print_comma_list pp_name) names
-            | _ ->
-                fprintf ppf "drop (vars=[%a], names=[%a])"
-                    (pp_print_comma_list pp_var) vars
-                    (pp_print_comma_list pp_name) names
-        end
-    | Dup vars ->
-        let pp_var ppf (var, count) = fprintf ppf "\"%s\":%d" (Var.unique_name var) count in
-        fprintf ppf "dup (%a)"
-            (pp_print_comma_list pp_var) vars
 and pp_value ppf v =
     pp_value_node ppf (WithIrMetadata.node v)
 and pp_value_node ppf value =

--- a/lib/frontend/pipeline.ml
+++ b/lib/frontend/pipeline.ml
@@ -16,22 +16,23 @@ let typecheck p ir =
                 "=== Intermediate Representation: ===\n%a\n\n"
                 (Ir.pp_program) ir
     in
-    let () =
-        if Settings.(get show_ref_counting) then
-            Format.printf
-                "=== With Reference Counting: ===\n%a\n\n"
-                Interp.Evaluation_ir.pp_program
-                (with_reference_counting ir)
-    in
     let ir, prety_opt = Typecheck.Pretypecheck.check ir in
     let (ty, env, constrs) = Typecheck.Gen_constraints.synthesise_program ir in
     let solution = Typecheck.Solve_constraints.solve_constraints constrs in
     let p = Sugar_ast.substitute_solution solution p in
     let ir = Ir.substitute_solution solution ir in
     let () =
-        if not Settings.(get typecheck_only) then
+        if Settings.(get show_ref_counting) || not Settings.(get typecheck_only) then
             let rc_ir = with_reference_counting ir in
-            Interp.Eval.run_program rc_ir
+            let () =
+                if Settings.(get show_ref_counting) then
+                    Format.printf
+                        "=== With Reference Counting: ===\n%a\n\n"
+                        Interp.Evaluation_ir.pp_program
+                        rc_ir
+            in
+            if not Settings.(get typecheck_only) then
+                Interp.Eval.run_program rc_ir
     in
     (p, prety_opt, ir, ty, env, constrs)
 

--- a/lib/frontend/pipeline.ml
+++ b/lib/frontend/pipeline.ml
@@ -6,8 +6,8 @@ let desugar p =
     |> Desugar_let_annotations.desugar
     |> Desugar_sugared_guards.desugar
 
-let with_reference_counting prog : Ir.program = 
-    Interp.Reference_counting.insert_reference_counting prog 
+let with_reference_counting prog : Interp.Evaluation_ir.program =
+    Interp.Reference_counting.insert_reference_counting prog
 
 let typecheck p ir = 
     let () =
@@ -20,7 +20,7 @@ let typecheck p ir =
         if Settings.(get show_ref_counting) then
             Format.printf
                 "=== With Reference Counting: ===\n%a\n\n"
-                Ir.pp_program
+                Interp.Evaluation_ir.pp_program
                 (with_reference_counting ir)
     in
     let ir, prety_opt = Typecheck.Pretypecheck.check ir in

--- a/lib/interp/eval.ml
+++ b/lib/interp/eval.ml
@@ -397,15 +397,11 @@ let rec step_current runtime state =
           ref, extend the env with param -> arg mappings, and eval body *) 
         | Name name ->
           let (lambda, fvs, closure_env) = Runtime.lookup_lambda runtime name in
-          let dup_cmd = WithIrMetadata.make (Ir.Dup (List.map (fun n -> (n, 1)) (VarSet.elements fvs))) in
-          let drop_cmd = WithIrMetadata.make (Ir.Drop { vars = []; names = [ (name, 1) ] }) in
+          let dup_names = lookup_runtime_names state.env (List.map (fun n -> (n, 1)) (VarSet.elements fvs)) in
+          Runtime.dup runtime dup_names;
+          Runtime.drop runtime [ (name, 1) ];
           let extended_env = bind_many_rt (List.map fst lambda.parameters) args closure_env in
-          let new_stack =
-            SeqFrame { saved_env = state.env; next_comp = drop_cmd }
-            :: SeqFrame { saved_env = extended_env; next_comp = lambda.body }
-            :: state.stack
-          in
-          finish_current { state with current_comp = dup_cmd; stack = new_stack }
+          finish_current { state with current_comp = lambda.body; env = extended_env }
         | other ->
           runtime_error
             (Format.asprintf
@@ -441,14 +437,7 @@ let rec step_current runtime state =
           (Format.asprintf "Expected sum value for case analysis, got: %a" pp_value (force_value state.env term))
       end
       *)
-    | Dup vars ->
-      let names = lookup_runtime_names state.env vars in
-      Runtime.dup runtime names;
-      return_unit state
-    | Drop { vars; names } ->
-      let var_names = lookup_runtime_names state.env vars in
-      Runtime.drop runtime (var_names @ names);
-      return_unit state
+
     | New _ -> return state (WithIrMetadata.make <| Ir.Name (Runtime.new_mailbox runtime))
     | Send { target; message = (tag, payloads); iname = _ } ->
       let mb_name = runtime_name_of_value state.env target in

--- a/lib/interp/eval.ml
+++ b/lib/interp/eval.ml
@@ -8,6 +8,12 @@ let max_steps_before_yield = 20
 module VarMap = Runtime_common.VarMap
 module RuntimeNameMap = Map.Make(RuntimeName)
 
+let count_names names =
+  List.fold_left
+    (fun acc n -> RuntimeNameMap.update n (function Some c -> Some (c + 1) | None -> Some 1) acc)
+    RuntimeNameMap.empty names
+  |> RuntimeNameMap.bindings
+
 let unit_value = Tuple []
 let mk_const c = Constant c
 let mk_name a = Name a
@@ -97,6 +103,8 @@ let lookup_runtime_names env vars =
       | None -> None
       | Some name -> Some (name, count))
     vars
+  
+let lookup_runtime_name env n = lookup_env env n |> runtime_name_of_runtime_value
 
 (* Looks up the definition, free variable set, and stored environment of a closure. *)
 let lookup_lambda runtime name =
@@ -149,6 +157,8 @@ let handle_return runtime state value =
     | SeqFrame { saved_env; next_comp } :: other_frames ->
         Stepped { state with current_comp = next_comp; env = saved_env; stack = other_frames }
     | LetFrame { binder; saved_env; next_comp } :: other_frames ->
+      (* should_ref_count: returns true for all values that need special treatment for
+          reference counting. Here: constructors, tuples, closures. *)
       if Runtime_common.should_ref_count forced then
         let new_ref = Runtime.record_value runtime forced in
         let env' =
@@ -183,16 +193,6 @@ let bool_of_value decls env value =
   | forced ->
     runtime_error
       (Format.asprintf "Expected boolean test value, got: %a" RuntimeValue.pp forced)
-
-let tuple_values_of_var decls env var =
-  (* FIXME: if the tuple was heap-allocated (returned via a `let`), var resolves to a
-     RuntimeValue.Name rather than a Tuple; need a Perceus-style borrow/dereference through
-     the RC table here (cf. lookup_lambda, which only handles the Closure case). *)
-  match force_var decls env var with
-  | RuntimeValue.Tuple values -> values
-  | forced ->
-    runtime_error
-      (Format.asprintf "Expected tuple value, got: %a" RuntimeValue.pp forced)
 
 let int_of_value value =
   match value with
@@ -403,40 +403,45 @@ let rec step_current runtime state =
     (* App: Check whether applying a primitive or variable. If a primitive, handle separately.
         If a variable, looks up in declarations; if a primitive, handles directly *)
     | App { func; args } ->
-      let func = force_var state.decls state.env func in
       let args = List.map (force_value state.decls state.env) args in
       begin
         let open RuntimeValue in
         (* We will never map the function variable directly to a closure as this
           is always reference-counted, so no need to handle that case. *)
         match func with
-        | Primitive prim ->
-          let result = apply_primitive runtime prim args in
-          finish_current { state with current_comp = Return result }
-        | Declaration var ->
-          begin
-            match VarMap.find_opt var state.decls with
-            | None ->
+        | UserFunction v ->
+          begin match force_var state.decls state.env v with
+            | Primitive prim ->
+              let result = apply_primitive runtime prim args in
+              finish_current { state with current_comp = Return result }
+            | Declaration var ->
+              begin
+                match VarMap.find_opt var state.decls with
+                | None ->
+                  runtime_error
+                    (Format.asprintf "Attempted to call unknown declaration %a" Var.pp var)
+                | Some decl ->
+                  let call_env = bind_many_rt decl.decl_parameters args VarMap.empty in
+                  finish_current { state with current_comp = decl.decl_body; env = call_env }
+              end
+            (* We've previously bound the function. Need to dup its FVs, drop a
+              ref, extend the env with param -> arg mappings, and eval body *) 
+            | Name name ->
+              let (lambda, fvs, closure_env) = lookup_lambda runtime name in
+              let dup_names = lookup_runtime_names state.env (List.map (fun n -> (n, 1)) (VarSet.elements fvs)) in
+              Runtime.dup runtime dup_names;
+              Runtime.drop runtime [ (name, 1) ];
+              let extended_env = bind_many_rt lambda.parameters args closure_env in
+              finish_current { state with current_comp = lambda.body; env = extended_env }
+            | other ->
               runtime_error
-                (Format.asprintf "Attempted to call unknown declaration %a" Var.pp var)
-            | Some decl ->
-              let call_env = bind_many_rt decl.decl_parameters args VarMap.empty in
-              finish_current { state with current_comp = decl.decl_body; env = call_env }
-          end
-        (* We've previously bound the function. Need to dup its FVs, drop a
-          ref, extend the env with param -> arg mappings, and eval body *) 
-        | Name name ->
-          let (lambda, fvs, closure_env) = lookup_lambda runtime name in
-          let dup_names = lookup_runtime_names state.env (List.map (fun n -> (n, 1)) (VarSet.elements fvs)) in
-          Runtime.dup runtime dup_names;
-          Runtime.drop runtime [ (name, 1) ];
-          let extended_env = bind_many_rt lambda.parameters args closure_env in
-          finish_current { state with current_comp = lambda.body; env = extended_env }
-        | other ->
-          runtime_error
-            (Format.asprintf
-              "Function position must be a declaration, lambda, or primitive, but got %a"
-              RuntimeValue.pp other)
+                (Format.asprintf
+                  "Function position must be a declaration, lambda, or primitive, but got %a"
+                  RuntimeValue.pp other)
+            end
+        | PrimitiveFunction p ->
+          let result = apply_primitive runtime p args in
+              finish_current { state with current_comp = Return result }
       end
     | If { test; then_expr; else_expr } ->
       if bool_of_value state.decls state.env test then
@@ -444,43 +449,42 @@ let rec step_current runtime state =
       else
         finish_current { state with current_comp = else_expr }
     | LetTuple { binders; tuple; cont } ->
-      let tuple_values = tuple_values_of_var state.decls state.env tuple in
-      if List.length binders <> List.length tuple_values then
-        runtime_error "Tuple arity mismatch in let-tuple";
-      let env' = bind_many_rt binders tuple_values state.env in
-      finish_current { state with current_comp = cont; env = env' }
-    | Case _ ->
-      (*
+      let tuple_name = runtime_name_of_var state.env tuple in
+      let tuple_values = lookup_tuple runtime tuple_name in
+      let names_in_values = List.filter_map (function
+          | RuntimeValue.Name n -> Some n
+          | _ -> None
+          ) tuple_values
+        in
+        let dup_names = count_names names_in_values in
+        Runtime.dup runtime dup_names;
+        Runtime.drop runtime [ (tuple_name, 1) ];
+        if List.length binders <> List.length tuple_values then
+          runtime_error "Tuple arity mismatch in let-tuple";
+        let env' = bind_many_rt binders tuple_values state.env in
+        finish_current { state with current_comp = cont; env = env' }
+    | Case { scrutinee; branches; _ } ->
         let scrutinee_name = runtime_name_of_var state.env scrutinee in
         let (constructor, arguments) = lookup_constructor runtime scrutinee_name in
-        let dup_names = lookup_runtime_names state.env (List.map (fun n -> (n, 1)) (VarSet.elements fvs)) in
+        let names_in_args = List.filter_map (function
+          | RuntimeValue.Name n -> Some n
+          | _ -> None
+          ) arguments
+        in
+        let dup_names = count_names names_in_args in
         Runtime.dup runtime dup_names;
-        Runtime.drop runtime [ (name, 1) ];
-        let extended_env = bind_many_rt lambda.parameters args closure_env in
-        finish_current { state with current_comp = lambda.body; env = extended_env }
-        *)
-        failwith "TODO"
-(*
-
-        (* FIXME: same Name-vs-Inject dereferencing gap as tuple_values_of_var above. *)
-        match force_var state.decls state.env scrutinee with
-        | RuntimeValue.Inject (tag, values) ->
-          begin
-            match List.find_opt (fun (_, _, name) -> String.equal name tag) branches with
+        Runtime.drop runtime [ (scrutinee_name, 1) ];
+        begin
+            match List.find_opt (fun (_, _, name) -> String.equal name constructor) branches with
             | None ->
               runtime_error
-                (Format.asprintf "No matching case branch for constructor '%s'" tag)
+                (Format.asprintf "No matching case branch for constructor '%s'" constructor)
             | Some (binders, branch_body, _) ->
-              if List.length binders <> List.length values then
+              if List.length binders <> List.length arguments then
                 runtime_error "Constructor arity mismatch in case expression";
-              let env' = bind_many_rt binders values state.env in
+              let env' = bind_many_rt binders arguments state.env in
               finish_current { state with current_comp = branch_body; env = env' }
-          end
-        | other ->
-          runtime_error
-            (Format.asprintf "Expected a data constructor for case analysis, got: %a" RuntimeValue.pp other)
-      end
-      *)
+        end
     | New _ -> return state (Name (Runtime.new_mailbox runtime))
     | Send { target; message = (tag, payloads); iname = _ } ->
       let mb_name = runtime_name_of_value state.env target in

--- a/lib/interp/eval.ml
+++ b/lib/interp/eval.ml
@@ -85,28 +85,11 @@ let unwrap_runtime_name = function
 let force_runtime_name env var =
   force_var VarMap.empty env var |> unwrap_runtime_name
 
-
-let runtime_name_of_var env var =
-  match VarMap.find_opt var env with
-  | Some (RuntimeValue.Name n) -> n
-  | Some _ -> runtime_error "Non runtime-name in runtime_name_of_var"
-  | None -> runtime_error (Format.asprintf "Unbound variable: %a" Var.pp var)
-
-
-let lookup_runtime_names env var =
-  List.concat_map
-    (fun var ->
-      lookup_env env var |> runtime_names_in_runtime_value) var
-  |> count_names
-
-(* Like lookup_runtime_names, but aggregates count, used for Dup/Drop *)
-let lookup_weighted_runtime_names env vars =
-  vars
-  |> List.concat_map (fun (var, count) ->
-      lookup_env env var
-      |> runtime_names_in_runtime_value
-      |> List.concat_map (fun name -> List.init count (fun _ -> name)))
-  |> count_names
+let check_runtime_name env var =
+  let value = force_var VarMap.empty env var in
+  match value with
+    | RuntimeValue.Name rn -> Some rn
+    | _ -> None
 
 (* Looks up the definition, free variable set, and stored environment of a closure. *)
 let lookup_lambda runtime name =
@@ -432,7 +415,11 @@ let rec step_current runtime state =
               ref, extend the env with param -> arg mappings, and eval body *) 
             | Name name ->
               let (lambda, fvs, closure_env) = lookup_lambda runtime name in
-              let dup_names = lookup_runtime_names state.env (VarSet.elements fvs) in
+              let dup_names =
+                List.map 
+                  (fun var -> (force_runtime_name state.env var, 1))
+                  (VarSet.elements fvs)
+              in
               Runtime.dup runtime dup_names;
               Runtime.drop runtime [ (name, 1) ];
               let extended_env = bind_many_rt lambda.parameters args closure_env in
@@ -453,7 +440,7 @@ let rec step_current runtime state =
       else
         finish_current { state with current_comp = else_expr }
     | LetTuple { binders; tuple; cont } ->
-      let tuple_name = runtime_name_of_var state.env tuple in
+      let tuple_name = force_runtime_name state.env tuple in
       let tuple_values = lookup_tuple runtime tuple_name in
       let names_in_values = List.concat_map runtime_names_in_runtime_value tuple_values in
         Runtime.dup runtime (count_names names_in_values);
@@ -463,7 +450,7 @@ let rec step_current runtime state =
         let env' = bind_many_rt binders tuple_values state.env in
         finish_current { state with current_comp = cont; env = env' }
     | Case { scrutinee; branches; _ } ->
-        let scrutinee_name = runtime_name_of_var state.env scrutinee in
+        let scrutinee_name = force_runtime_name state.env scrutinee in
         let (constructor, arguments) = lookup_constructor runtime scrutinee_name in
         let names_in_args = List.concat_map runtime_names_in_runtime_value arguments in
         Runtime.dup runtime (count_names names_in_args);
@@ -515,11 +502,21 @@ let rec step_current runtime state =
       Runtime.free_mailbox runtime rt_name;
       return_unit state
     | Dup vars ->
-      let names = lookup_weighted_runtime_names state.env vars in
+      let names = 
+        List.concat_map (fun (value, c) ->
+          match check_runtime_name state.env value with
+          | Some rn -> [(rn, c)]
+          | _ -> []) vars
+      in
       Runtime.dup runtime names;
       return_unit state
     | Drop { vars; names } ->
-      let var_names = lookup_weighted_runtime_names state.env vars in
+      let var_names = 
+        List.concat_map (fun (value, c) ->
+          match check_runtime_name state.env value with
+          | Some rn -> [(rn, c)]
+          | _ -> []) vars
+      in
       Runtime.drop runtime (var_names @ names);
       return_unit state
     | Spawn comp ->

--- a/lib/interp/eval.ml
+++ b/lib/interp/eval.ml
@@ -18,7 +18,6 @@ let mk_const c = WithIrMetadata.make (Constant c)
 let mk_name a = WithIrMetadata.make (Name a)
 
 let runtime_of_ir env value = RuntimeValue.of_ir env value
-let ir_of_runtime value = RuntimeValue.to_ir value
 
 type environment = value_env
 
@@ -34,7 +33,7 @@ type computation_frame =
   }
 
 type computation_state = {
-  program: Ir.program;
+  decls: decl VarMap.t;
   current_comp: comp;
   env: environment;
   stack: computation_frame list
@@ -50,22 +49,32 @@ let lookup_env env var =
   | None ->
     runtime_error (Format.asprintf "Unbound runtime variable %a" Var.pp var)
 
-let rec force_value env value =
-  match get_node value with
-  | VAnnotate (v, _) -> force_value env v
-  | Variable (var, _) -> force_value env (ir_of_runtime (lookup_env env var))
-  | _ -> value
+let decl_map program =
+  List.fold_left
+    (fun acc decl ->
+      let var = Var.of_binder decl.decl_name in
+      VarMap.add var decl acc)
+    VarMap.empty
+    program.prog_decls
 
-let rec normalise_function_value env value =
+(* Fully resolves a value to a closed runtime value, substituting any free variables from the
+   environment. An unbound variable referring to a top-level declaration resolves to a
+   [Declaration], rather than being an error. *)
+let rec force_value decls env value : RuntimeValue.t =
   match get_node value with
-  | VAnnotate (v, _) -> normalise_function_value env v
+  | VAnnotate (v, _) -> force_value decls env v
   | Variable (var, _) ->
     begin
       match VarMap.find_opt var env with
-      | Some bound -> ir_of_runtime bound
-      | None -> value
+      | Some bound -> bound
+      | None ->
+        begin
+          match VarMap.find_opt var decls with
+          | Some _ -> RuntimeValue.Declaration var
+          | None -> runtime_error (Format.asprintf "Unbound variable: %a" Var.pp var)
+        end
     end
-  | _ -> value
+  | _ -> RuntimeValue.of_ir env value
 
 let runtime_name_of_value env value =
   match RuntimeValue.of_ir env value with
@@ -87,17 +96,8 @@ let lookup_runtime_names env vars =
       | Some name -> Some (name, count))
     vars
 
-let decl_map program =
-  List.fold_left
-    (fun acc decl ->
-      let var = Var.of_binder decl.decl_name in
-      VarMap.add var decl acc)
-    VarMap.empty
-    program.prog_decls
-
-
 let init_state program comp =
-  { program; current_comp = comp; env = VarMap.empty; stack = [] }
+  { decls = decl_map program; current_comp = comp; env = VarMap.empty; stack = [] }
 
 let install_seq_frame saved_env next_comp state =
   { state with stack = SeqFrame { saved_env; next_comp } :: state.stack }
@@ -105,26 +105,25 @@ let install_seq_frame saved_env next_comp state =
 let install_let_frame binder saved_env next_comp state =
   { state with stack = LetFrame { binder; saved_env; next_comp } :: state.stack }
 
+(* If the returned expression is a closure, tuple, or data constructor, then we
+   need to reference count it and return a runtime name. *)
 let handle_return runtime state value =
   (* We can only store a closed runtime value in the environment, so we need to substitute any FVs. *)
-  let forced = force_value state.env value in
-  let irv = runtime_of_ir state.env value in
-  match (get_node forced, state.stack) with
-    | (_, []) -> Finished
-    | (_, SeqFrame { saved_env; next_comp } :: other_frames) ->
-      Stepped { state with current_comp = next_comp; env = saved_env; stack = other_frames }
-    | (Lam _, LetFrame { binder; saved_env; next_comp } :: other_frames) ->
-      (* If we're returning a function or constructor, we need to generate a new 
-          function runtime name, store in the reference counted heap,
-          and return this instead of the lambda binding. *)
-      let new_ref = Runtime.record_value runtime irv in
-      let env' =
-        VarMap.add binder (RuntimeValue.Name new_ref) saved_env
-      in
-      Stepped { state with current_comp = next_comp; env = env'; stack = other_frames }
-    | (_, LetFrame { binder; saved_env; next_comp } :: other_frames) ->
-      let env' = VarMap.add binder irv saved_env in
-      Stepped { state with current_comp = next_comp; env = env'; stack = other_frames }
+  let forced = force_value state.decls state.env value in
+  match state.stack with
+    | [] -> Finished
+    | SeqFrame { saved_env; next_comp } :: other_frames ->
+        Stepped { state with current_comp = next_comp; env = saved_env; stack = other_frames }
+    | LetFrame { binder; saved_env; next_comp } :: other_frames ->
+      if Runtime_common.should_ref_count forced then
+        let new_ref = Runtime.record_value runtime forced in
+        let env' =
+          VarMap.add binder (RuntimeValue.Name new_ref) saved_env
+        in
+        Stepped { state with current_comp = next_comp; env = env'; stack = other_frames }
+      else
+        let env' = VarMap.add binder forced saved_env in
+        Stepped { state with current_comp = next_comp; env = env'; stack = other_frames }
 
 let rec bind_many binders values env =
   match binders, values with
@@ -144,45 +143,40 @@ let rec bind_many_rt binders values env =
 let bind binder value env =
   VarMap.add (Var.of_binder binder) (runtime_of_ir env value) env
 
-let bool_of_value env value =
-  let forced = force_value env value in
-  match get_node forced with
-  | Constant (Constant.Bool b) -> b
-  | _ ->
+let bool_of_value decls env value =
+  match force_value decls env value with
+  | RuntimeValue.Constant (Constant.Bool b) -> b
+  | forced ->
     runtime_error
-      (Format.asprintf "Expected boolean test value, got: %a" pp_value forced)
+      (Format.asprintf "Expected boolean test value, got: %a" RuntimeValue.pp forced)
 
-let tuple_values_of_value env value =
-  let forced = force_value env value in
-  match get_node forced with
-  | Tuple values -> values
-  | _ ->
+let tuple_values_of_value decls env value =
+  match force_value decls env value with
+  | RuntimeValue.Tuple values -> values
+  | forced ->
     runtime_error
-      (Format.asprintf "Expected tuple value, got: %a" pp_value forced)
+      (Format.asprintf "Expected tuple value, got: %a" RuntimeValue.pp forced)
 
-let int_of_value env value =
-  let forced = force_value env value in
-  match get_node forced with
-  | Constant (Constant.Int i) -> i
+let int_of_value value =
+  match value with
+  | RuntimeValue.Constant (Constant.Int i) -> i
   | _ ->
     runtime_error
-      (Format.asprintf "Expected integer value, got: %a" pp_value forced)
+      (Format.asprintf "Expected integer value, got: %a" RuntimeValue.pp value)
 
-let string_of_value env value =
-  let forced = force_value env value in
-  match get_node forced with
-  | Constant (Constant.String s) -> s
+let string_of_value value =
+  match value with
+  | RuntimeValue.Constant (Constant.String s) -> s
   | _ ->
     runtime_error
-      (Format.asprintf "Expected string value, got: %a" pp_value forced)
+      (Format.asprintf "Expected string value, got: %a" RuntimeValue.pp value)
 
-let bool_runtime_of_value env value =
-  let forced = force_value env value in
-  match get_node forced with
-  | Constant (Constant.Bool b) -> b
+let bool_runtime_of_value value =
+  match value with
+  | RuntimeValue.Constant (Constant.Bool b) -> b
   | _ ->
     runtime_error
-      (Format.asprintf "Expected boolean value, got: %a" pp_value forced)
+      (Format.asprintf "Expected boolean value, got: %a" RuntimeValue.pp value)
 
 let expect_arity prim expected args =
   let actual = List.length args in
@@ -199,27 +193,27 @@ let bool_const b =
 let string_const s =
   mk_const (Constant.String s)
 
-let apply_primitive runtime prim env args =
+let apply_primitive runtime prim args =
   match prim with
   | "+" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> int_const (int_of_value env x + int_of_value env y)
+      | [x; y] -> int_const (int_of_value x + int_of_value y)
       | _ -> assert false
     end
   | "-" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> int_const (int_of_value env x - int_of_value env y)
+      | [x; y] -> int_const (int_of_value x - int_of_value y)
       | _ -> assert false
     end
   | "*" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> int_const (int_of_value env x * int_of_value env y)
+      | [x; y] -> int_const (int_of_value x * int_of_value y)
       | _ -> assert false
     end
   | "/" ->
@@ -227,65 +221,65 @@ let apply_primitive runtime prim env args =
     begin
       match args with
       | [x; y] ->
-        let denom = int_of_value env y in
+        let denom = int_of_value y in
         if denom = 0 then runtime_error "Division by zero in primitive '/'";
-        int_const (int_of_value env x / denom)
+        int_const (int_of_value x / denom)
       | _ -> assert false
     end
   | "<" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> bool_const (int_of_value env x < int_of_value env y)
+      | [x; y] -> bool_const (int_of_value x < int_of_value y)
       | _ -> assert false
     end
   | "<=" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> bool_const (int_of_value env x <= int_of_value env y)
+      | [x; y] -> bool_const (int_of_value x <= int_of_value y)
       | _ -> assert false
     end
   | ">" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> bool_const (int_of_value env x > int_of_value env y)
+      | [x; y] -> bool_const (int_of_value x > int_of_value y)
       | _ -> assert false
     end
   | ">=" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> bool_const (int_of_value env x >= int_of_value env y)
+      | [x; y] -> bool_const (int_of_value x >= int_of_value y)
       | _ -> assert false
     end
   | "==" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> bool_const (int_of_value env x = int_of_value env y)
+      | [x; y] -> bool_const (int_of_value x = int_of_value y)
       | _ -> assert false
     end
   | "!=" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> bool_const (int_of_value env x <> int_of_value env y)
+      | [x; y] -> bool_const (int_of_value x <> int_of_value y)
       | _ -> assert false
     end
   | "&&" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> bool_const (bool_runtime_of_value env x && bool_runtime_of_value env y)
+      | [x; y] -> bool_const (bool_runtime_of_value x && bool_runtime_of_value y)
       | _ -> assert false
     end
   | "||" ->
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> bool_const (bool_runtime_of_value env x || bool_runtime_of_value env y)
+      | [x; y] -> bool_const (bool_runtime_of_value x || bool_runtime_of_value y)
       | _ -> assert false
     end
   | "print" ->
@@ -293,7 +287,7 @@ let apply_primitive runtime prim env args =
     begin
       match args with
       | [x] ->
-        print_endline (string_of_value env x);
+        print_endline (string_of_value x);
         unit_value
       | _ -> assert false
     end
@@ -301,7 +295,7 @@ let apply_primitive runtime prim env args =
     expect_arity prim 2 args;
     begin
       match args with
-      | [x; y] -> string_const (string_of_value env x ^ string_of_value env y)
+      | [x; y] -> string_const (string_of_value x ^ string_of_value y)
       | _ -> assert false
     end
   | "rand" ->
@@ -309,7 +303,7 @@ let apply_primitive runtime prim env args =
     begin
       match args with
       | [x] ->
-        let bound = int_of_value env x in
+        let bound = int_of_value x in
         if bound <= 0 then runtime_error "Primitive 'rand' expects a positive integer bound";
         int_const (Random.int bound)
       | _ -> assert false
@@ -322,7 +316,7 @@ let apply_primitive runtime prim env args =
     begin
       match args with
       | [x] ->
-        let duration = int_of_value env x in
+        let duration = int_of_value x in
         if duration <= 0 then runtime_error "Primitive 'sleep' expects a positive integer duration";
         Runtime.sleep runtime duration;
         unit_value
@@ -333,7 +327,7 @@ let apply_primitive runtime prim env args =
     expect_arity prim 1 args;
     begin
       match args with
-      | [x] -> string_const (string_of_int (int_of_value env x))
+      | [x] -> string_const (string_of_int (int_of_value x))
       | _ -> assert false
     end
   | _ ->
@@ -374,28 +368,30 @@ let rec step_current runtime state =
     (* App: Check whether applying a primitive or variable. If a primitive, handle separately.
         If a variable, looks up in declarations; if a primitive, handles directly *)
     | App { func; args } ->
-      let func = normalise_function_value state.env func in
-      let args = List.map (force_value state.env) args in
+      let func = force_value state.decls state.env func in
+      let args = List.map (force_value state.decls state.env) args in
       begin
-        match get_node func with
+        let open RuntimeValue in
+        match func with
         | Primitive prim ->
-          let result = apply_primitive runtime prim state.env args in
+          let result = apply_primitive runtime prim args in
           finish_current { state with current_comp = with_val_fvs result (Return result) }
-        | Variable (var, _) ->
-          let decls = decl_map state.program in
+        | Declaration var ->
           begin
-            match VarMap.find_opt var decls with
-            | None -> runtime_error "Attempted to call unknown declaration"
+            match VarMap.find_opt var state.decls with
+            | None ->
+              runtime_error
+                (Format.asprintf "Attempted to call unknown declaration %a" Var.pp var)
             | Some decl ->
               let binders = List.map fst decl.decl_parameters in
-              let call_env = bind_many binders args VarMap.empty in
+              let call_env = bind_many_rt binders args VarMap.empty in
               finish_current { state with current_comp = decl.decl_body; env = call_env }
           end
         (* Applying a function literal. We don't need to heap-allocate this, or do anything
             special with closures, as it can't be re-called. *)
-        | Lam lambda ->
+        | Closure { lambda; value_env } ->
             let binders = List.map fst lambda.parameters in
-            let extended_env = bind_many binders args state.env in
+            let extended_env = bind_many_rt binders args value_env in
             finish_current { state with current_comp = lambda.body; env = extended_env  }
         (* We've previously bound the function. Need to dup its FVs, drop a
           ref, extend the env with param -> arg mappings, and eval body *) 
@@ -403,7 +399,7 @@ let rec step_current runtime state =
           let (lambda, fvs, closure_env) = Runtime.lookup_lambda runtime name in
           let dup_cmd = WithIrMetadata.make (Ir.Dup (List.map (fun n -> (n, 1)) (VarSet.elements fvs))) in
           let drop_cmd = WithIrMetadata.make (Ir.Drop { vars = []; names = [ (name, 1) ] }) in
-          let extended_env = bind_many (List.map fst lambda.parameters) args closure_env in
+          let extended_env = bind_many_rt (List.map fst lambda.parameters) args closure_env in
           let new_stack =
             SeqFrame { saved_env = state.env; next_comp = drop_cmd }
             :: SeqFrame { saved_env = extended_env; next_comp = lambda.body }
@@ -414,19 +410,19 @@ let rec step_current runtime state =
           runtime_error
             (Format.asprintf
               "Function position must be a declaration, lambda, or primitive, but got %a"
-              Ir.pp_value_node other)
+              RuntimeValue.pp other)
       end
     | If { test; then_expr; else_expr } ->
-      if bool_of_value state.env test then
+      if bool_of_value state.decls state.env test then
         finish_current { state with current_comp = then_expr }
       else
         finish_current { state with current_comp = else_expr }
     | LetTuple { binders; tuple; cont } ->
-      let tuple_values = tuple_values_of_value state.env tuple in
+      let tuple_values = tuple_values_of_value state.decls state.env tuple in
       let tuple_binders = List.map fst binders in
       if List.length tuple_binders <> List.length tuple_values then
         runtime_error "Tuple arity mismatch in let-tuple";
-      let env' = bind_many tuple_binders tuple_values state.env in
+      let env' = bind_many_rt tuple_binders tuple_values state.env in
       finish_current { state with current_comp = cont; env = env' }
     | Case _ ->
       runtime_error "Evaluating case-expressions not yet implemented"
@@ -489,7 +485,7 @@ let rec step_current runtime state =
     | Spawn comp ->
       Runtime.spawn runtime
         (fun () -> 
-          let st = { program = state.program; current_comp = comp;
+          let st = { decls = state.decls; current_comp = comp;
                      env = state.env; stack = [] } in
           step runtime st);
       return_unit state

--- a/lib/interp/eval.ml
+++ b/lib/interp/eval.ml
@@ -6,14 +6,6 @@ open Runtime_common
 let max_steps_before_yield = 20
 
 module VarMap = Runtime_common.VarMap
-module RuntimeNameMap = Map.Make(RuntimeName)
-
-let count_names names =
-  List.fold_left
-    (fun acc n -> RuntimeNameMap.update n (function Some c -> Some (c + 1) | None -> Some 1) acc)
-    RuntimeNameMap.empty names
-  |> RuntimeNameMap.bindings
-
 let unit_value = Tuple []
 let mk_const c = Constant c
 let mk_name a = Name a
@@ -84,10 +76,15 @@ let runtime_name_of_value env value =
     runtime_error
       (Format.asprintf "Expected a mailbox runtime name value, got: %a" RuntimeValue.pp v)
 
-let runtime_name_of_runtime_value value =
-  match value with
-  | RuntimeValue.Name runtime_name -> Some runtime_name
-  | _ -> None
+let unwrap_runtime_name = function
+  | RuntimeValue.Name runtime_name -> runtime_name
+  | v ->
+    runtime_error
+      (Format.asprintf "Expected a mailbox runtime name value, got: %a" RuntimeValue.pp v)
+
+let force_runtime_name env var =
+  force_var VarMap.empty env var |> unwrap_runtime_name
+
 
 let runtime_name_of_var env var =
   match VarMap.find_opt var env with
@@ -96,15 +93,20 @@ let runtime_name_of_var env var =
   | None -> runtime_error (Format.asprintf "Unbound variable: %a" Var.pp var)
 
 
-let lookup_runtime_names env vars =
-  List.filter_map
-    (fun (var, count) ->
-      match lookup_env env var |> runtime_name_of_runtime_value with
-      | None -> None
-      | Some name -> Some (name, count))
-    vars
-  
-let lookup_runtime_name env n = lookup_env env n |> runtime_name_of_runtime_value
+let lookup_runtime_names env var =
+  List.concat_map
+    (fun var ->
+      lookup_env env var |> runtime_names_in_runtime_value) var
+  |> count_names
+
+(* Like lookup_runtime_names, but aggregates count, used for Dup/Drop *)
+let lookup_weighted_runtime_names env vars =
+  vars
+  |> List.concat_map (fun (var, count) ->
+      lookup_env env var
+      |> runtime_names_in_runtime_value
+      |> List.concat_map (fun name -> List.init count (fun _ -> name)))
+  |> count_names
 
 (* Looks up the definition, free variable set, and stored environment of a closure. *)
 let lookup_lambda runtime name =
@@ -403,7 +405,9 @@ let rec step_current runtime state =
     (* App: Check whether applying a primitive or variable. If a primitive, handle separately.
         If a variable, looks up in declarations; if a primitive, handles directly *)
     | App { func; args } ->
-      let args = List.map (force_value state.decls state.env) args in
+      (* args are bare variables post let-insertion; force_var (rather than a plain env
+         lookup) so a top-level function passed by name still resolves to a Declaration. *)
+      let args = List.map (force_var state.decls state.env) args in
       begin
         let open RuntimeValue in
         (* We will never map the function variable directly to a closure as this
@@ -428,7 +432,7 @@ let rec step_current runtime state =
               ref, extend the env with param -> arg mappings, and eval body *) 
             | Name name ->
               let (lambda, fvs, closure_env) = lookup_lambda runtime name in
-              let dup_names = lookup_runtime_names state.env (List.map (fun n -> (n, 1)) (VarSet.elements fvs)) in
+              let dup_names = lookup_runtime_names state.env (VarSet.elements fvs) in
               Runtime.dup runtime dup_names;
               Runtime.drop runtime [ (name, 1) ];
               let extended_env = bind_many_rt lambda.parameters args closure_env in
@@ -451,11 +455,7 @@ let rec step_current runtime state =
     | LetTuple { binders; tuple; cont } ->
       let tuple_name = runtime_name_of_var state.env tuple in
       let tuple_values = lookup_tuple runtime tuple_name in
-      let names_in_values = List.filter_map (function
-          | RuntimeValue.Name n -> Some n
-          | _ -> None
-          ) tuple_values
-        in
+      let names_in_values = List.concat_map runtime_names_in_runtime_value tuple_values in
         Runtime.dup runtime (count_names names_in_values);
         Runtime.drop runtime [ (tuple_name, 1) ];
         if List.length binders <> List.length tuple_values then
@@ -465,11 +465,7 @@ let rec step_current runtime state =
     | Case { scrutinee; branches; _ } ->
         let scrutinee_name = runtime_name_of_var state.env scrutinee in
         let (constructor, arguments) = lookup_constructor runtime scrutinee_name in
-        let names_in_args = List.filter_map (function
-          | RuntimeValue.Name n -> Some n
-          | _ -> None
-          ) arguments
-        in
+        let names_in_args = List.concat_map runtime_names_in_runtime_value arguments in
         Runtime.dup runtime (count_names names_in_args);
         Runtime.drop runtime [ (scrutinee_name, 1) ];
         begin
@@ -486,7 +482,9 @@ let rec step_current runtime state =
     | New _ -> return state (Name (Runtime.new_mailbox runtime))
     | Send { target; message = (tag, payloads); iname = _ } ->
       let mb_name = runtime_name_of_value state.env target in
-      let runtime_message = (tag, List.map (RuntimeValue.of_ir state.env) payloads) in
+      (* Payloads are bare variables post let-insertion; resolving them yields the tracked
+         runtime name for any heap value, which is what gets stored in the mailbox. *)
+      let runtime_message = (tag, List.map (force_var state.decls state.env) payloads) in
       Runtime.send runtime mb_name runtime_message;
       return_unit state
     | Guard { target; guards; _ } ->
@@ -517,11 +515,11 @@ let rec step_current runtime state =
       Runtime.free_mailbox runtime rt_name;
       return_unit state
     | Dup vars ->
-      let names = lookup_runtime_names state.env vars in
+      let names = lookup_weighted_runtime_names state.env vars in
       Runtime.dup runtime names;
       return_unit state
     | Drop { vars; names } ->
-      let var_names = lookup_runtime_names state.env vars in
+      let var_names = lookup_weighted_runtime_names state.env vars in
       Runtime.drop runtime (var_names @ names);
       return_unit state
     | Spawn comp ->

--- a/lib/interp/eval.ml
+++ b/lib/interp/eval.ml
@@ -456,8 +456,7 @@ let rec step_current runtime state =
           | _ -> None
           ) tuple_values
         in
-        let dup_names = count_names names_in_values in
-        Runtime.dup runtime dup_names;
+        Runtime.dup runtime (count_names names_in_values);
         Runtime.drop runtime [ (tuple_name, 1) ];
         if List.length binders <> List.length tuple_values then
           runtime_error "Tuple arity mismatch in let-tuple";
@@ -471,8 +470,7 @@ let rec step_current runtime state =
           | _ -> None
           ) arguments
         in
-        let dup_names = count_names names_in_args in
-        Runtime.dup runtime dup_names;
+        Runtime.dup runtime (count_names names_in_args);
         Runtime.drop runtime [ (scrutinee_name, 1) ];
         begin
             match List.find_opt (fun (_, _, name) -> String.equal name constructor) branches with

--- a/lib/interp/eval.ml
+++ b/lib/interp/eval.ml
@@ -112,7 +112,7 @@ let lookup_lambda runtime name =
     | bad ->
       runtime_error
         (Format.asprintf "Looking up lambda in RC map: name %a maps to non-lambda %a"
-          RuntimeName.pp name Evaluation_ir.pp_value (RuntimeValue.to_ir bad))
+          RuntimeName.pp name RuntimeValue.pp bad)
 
 let lookup_constructor runtime name =
   match Runtime.lookup_tracked_value runtime name with
@@ -120,7 +120,7 @@ let lookup_constructor runtime name =
     | bad ->
       runtime_error
         (Format.asprintf "Looking up inject in RC map: name %a maps to non-inject %a"
-          RuntimeName.pp name Evaluation_ir.pp_value (RuntimeValue.to_ir bad))
+          RuntimeName.pp name RuntimeValue.pp bad)
 
 let lookup_tuple runtime name =
   match Runtime.lookup_tracked_value runtime name with
@@ -128,7 +128,7 @@ let lookup_tuple runtime name =
     | bad ->
       runtime_error
         (Format.asprintf "Looking up tuple in RC map: name %a maps to non-tuple %a"
-          RuntimeName.pp name Evaluation_ir.pp_value (RuntimeValue.to_ir bad))
+          RuntimeName.pp name RuntimeValue.pp bad)
 
 let init_state program comp =
   { decls = decl_map program; current_comp = comp; env = VarMap.empty; stack = [] }

--- a/lib/interp/eval.ml
+++ b/lib/interp/eval.ml
@@ -1,7 +1,6 @@
 open Common
 open Common_types
-open Util.Utility
-open Ir
+open Evaluation_ir
 open Runtime_common
 
 let max_steps_before_yield = 20
@@ -9,13 +8,9 @@ let max_steps_before_yield = 20
 module VarMap = Runtime_common.VarMap
 module RuntimeNameMap = Map.Make(RuntimeName)
 
-let get_node = WithIrMetadata.node
-let get_fvs = WithIrMetadata.fvs
-let with_val_fvs value = WithIrMetadata.make ~fvs:(get_fvs value)
-
-let unit_value = WithIrMetadata.make (Tuple [])
-let mk_const c = WithIrMetadata.make (Constant c)
-let mk_name a = WithIrMetadata.make (Name a)
+let unit_value = Tuple []
+let mk_const c = Constant c
+let mk_name a = Name a
 
 let runtime_of_ir env value = RuntimeValue.of_ir env value
 
@@ -57,23 +52,23 @@ let decl_map program =
     VarMap.empty
     program.prog_decls
 
-(* Fully resolves a value to a closed runtime value, substituting any free variables from the
-   environment. An unbound variable referring to a top-level declaration resolves to a
-   [Declaration], rather than being an error. *)
-let rec force_value decls env value : RuntimeValue.t =
-  match get_node value with
-  | VAnnotate (v, _) -> force_value decls env v
-  | Variable (var, _) ->
+(* Resolves a bare variable to a closed runtime value. An unbound variable referring
+   to a top-level declaration resolves to a [Declaration], rather than being an error. *)
+let force_var decls env var : RuntimeValue.t =
+  match VarMap.find_opt var env with
+  | Some bound -> bound
+  | None ->
     begin
-      match VarMap.find_opt var env with
-      | Some bound -> bound
-      | None ->
-        begin
-          match VarMap.find_opt var decls with
-          | Some _ -> RuntimeValue.Declaration var
-          | None -> runtime_error (Format.asprintf "Unbound variable: %a" Var.pp var)
-        end
+      match VarMap.find_opt var decls with
+      | Some _ -> RuntimeValue.Declaration var
+      | None -> runtime_error (Format.asprintf "Unbound variable: %a" Var.pp var)
     end
+
+(* Fully resolves a value to a closed runtime value, substituting any free variables from the
+   environment. *)
+let force_value decls env value : RuntimeValue.t =
+  match value with
+  | Variable var -> force_var decls env var
   | _ -> RuntimeValue.of_ir env value
 
 let runtime_name_of_value env value =
@@ -88,6 +83,13 @@ let runtime_name_of_runtime_value value =
   | RuntimeValue.Name runtime_name -> Some runtime_name
   | _ -> None
 
+let runtime_name_of_var env var =
+  match VarMap.find_opt var env with
+  | Some (RuntimeValue.Name n) -> n
+  | Some _ -> runtime_error "Non runtime-name in runtime_name_of_var"
+  | None -> runtime_error (Format.asprintf "Unbound variable: %a" Var.pp var)
+
+
 let lookup_runtime_names env vars =
   List.filter_map
     (fun (var, count) ->
@@ -95,6 +97,38 @@ let lookup_runtime_names env vars =
       | None -> None
       | Some name -> Some (name, count))
     vars
+
+(* Looks up the definition, free variable set, and stored environment of a closure. *)
+let lookup_lambda runtime name =
+  match Runtime.lookup_tracked_value runtime name with
+    | RuntimeValue.Closure { lambda; value_env } ->
+      let fvs =
+        value_env
+        |> VarMap.bindings
+        |> List.map fst
+        |> VarSet.of_list
+      in
+      (lambda, fvs, value_env)
+    | bad ->
+      runtime_error
+        (Format.asprintf "Looking up lambda in RC map: name %a maps to non-lambda %a"
+          RuntimeName.pp name Evaluation_ir.pp_value (RuntimeValue.to_ir bad))
+
+let lookup_constructor runtime name =
+  match Runtime.lookup_tracked_value runtime name with
+    | RuntimeValue.Inject (tag, values) -> (tag, values)
+    | bad ->
+      runtime_error
+        (Format.asprintf "Looking up inject in RC map: name %a maps to non-inject %a"
+          RuntimeName.pp name Evaluation_ir.pp_value (RuntimeValue.to_ir bad))
+
+let lookup_tuple runtime name =
+  match Runtime.lookup_tracked_value runtime name with
+    | RuntimeValue.Tuple values -> values
+    | bad ->
+      runtime_error
+        (Format.asprintf "Looking up tuple in RC map: name %a maps to non-tuple %a"
+          RuntimeName.pp name Evaluation_ir.pp_value (RuntimeValue.to_ir bad))
 
 let init_state program comp =
   { decls = decl_map program; current_comp = comp; env = VarMap.empty; stack = [] }
@@ -150,8 +184,11 @@ let bool_of_value decls env value =
     runtime_error
       (Format.asprintf "Expected boolean test value, got: %a" RuntimeValue.pp forced)
 
-let tuple_values_of_value decls env value =
-  match force_value decls env value with
+let tuple_values_of_var decls env var =
+  (* FIXME: if the tuple was heap-allocated (returned via a `let`), var resolves to a
+     RuntimeValue.Name rather than a Tuple; need a Perceus-style borrow/dereference through
+     the RC table here (cf. lookup_lambda, which only handles the Closure case). *)
+  match force_var decls env var with
   | RuntimeValue.Tuple values -> values
   | forced ->
     runtime_error
@@ -340,14 +377,12 @@ let rec step_current runtime state =
     finish_current { comp_state with current_comp = next }
   in
   let return comp_state value =
-    step_to comp_state (WithIrMetadata.make (Ir.Return value))
+    step_to comp_state (Return value)
   in
   let return_unit comp_state =
-    return comp_state (WithIrMetadata.make (Tuple []))
+    return comp_state (Tuple [])
   in
-  match get_node state.current_comp with
-    | Annotate (comp, _) ->
-      step_to state comp
+  match state.current_comp with
     (* Seq: install frame for comp2, evaluate comp1 *)
     | Seq (comp1, comp2) ->
       let next_current =
@@ -368,14 +403,16 @@ let rec step_current runtime state =
     (* App: Check whether applying a primitive or variable. If a primitive, handle separately.
         If a variable, looks up in declarations; if a primitive, handles directly *)
     | App { func; args } ->
-      let func = force_value state.decls state.env func in
+      let func = force_var state.decls state.env func in
       let args = List.map (force_value state.decls state.env) args in
       begin
         let open RuntimeValue in
+        (* We will never map the function variable directly to a closure as this
+          is always reference-counted, so no need to handle that case. *)
         match func with
         | Primitive prim ->
           let result = apply_primitive runtime prim args in
-          finish_current { state with current_comp = with_val_fvs result (Return result) }
+          finish_current { state with current_comp = Return result }
         | Declaration var ->
           begin
             match VarMap.find_opt var state.decls with
@@ -383,24 +420,17 @@ let rec step_current runtime state =
               runtime_error
                 (Format.asprintf "Attempted to call unknown declaration %a" Var.pp var)
             | Some decl ->
-              let binders = List.map fst decl.decl_parameters in
-              let call_env = bind_many_rt binders args VarMap.empty in
+              let call_env = bind_many_rt decl.decl_parameters args VarMap.empty in
               finish_current { state with current_comp = decl.decl_body; env = call_env }
           end
-        (* Applying a function literal. We don't need to heap-allocate this, or do anything
-            special with closures, as it can't be re-called. *)
-        | Closure { lambda; value_env } ->
-            let binders = List.map fst lambda.parameters in
-            let extended_env = bind_many_rt binders args value_env in
-            finish_current { state with current_comp = lambda.body; env = extended_env  }
         (* We've previously bound the function. Need to dup its FVs, drop a
           ref, extend the env with param -> arg mappings, and eval body *) 
         | Name name ->
-          let (lambda, fvs, closure_env) = Runtime.lookup_lambda runtime name in
+          let (lambda, fvs, closure_env) = lookup_lambda runtime name in
           let dup_names = lookup_runtime_names state.env (List.map (fun n -> (n, 1)) (VarSet.elements fvs)) in
           Runtime.dup runtime dup_names;
           Runtime.drop runtime [ (name, 1) ];
-          let extended_env = bind_many_rt (List.map fst lambda.parameters) args closure_env in
+          let extended_env = bind_many_rt lambda.parameters args closure_env in
           finish_current { state with current_comp = lambda.body; env = extended_env }
         | other ->
           runtime_error
@@ -414,31 +444,44 @@ let rec step_current runtime state =
       else
         finish_current { state with current_comp = else_expr }
     | LetTuple { binders; tuple; cont } ->
-      let tuple_values = tuple_values_of_value state.decls state.env tuple in
-      let tuple_binders = List.map fst binders in
-      if List.length tuple_binders <> List.length tuple_values then
+      let tuple_values = tuple_values_of_var state.decls state.env tuple in
+      if List.length binders <> List.length tuple_values then
         runtime_error "Tuple arity mismatch in let-tuple";
-      let env' = bind_many_rt tuple_binders tuple_values state.env in
+      let env' = bind_many_rt binders tuple_values state.env in
       finish_current { state with current_comp = cont; env = env' }
     | Case _ ->
-      runtime_error "Evaluating case-expressions not yet implemented"
       (*
-    | Case { term; branch1 = ((binder1, _), comp1); branch2 = ((binder2, _), comp2) } ->
-      begin
-        match get_node (force_value state.env term) with
-        | Inl value ->
-          let env' = VarMap.add (Var.of_binder binder1) (runtime_of_ir state.env value) state.env in
-          finish_current { state with current_comp = comp1; env = env' }
-        | Inr value ->
-          let env' = VarMap.add (Var.of_binder binder2) (runtime_of_ir state.env value) state.env in
-          finish_current { state with current_comp = comp2; env = env' }
-        | _ ->
-        runtime_error
-          (Format.asprintf "Expected sum value for case analysis, got: %a" pp_value (force_value state.env term))
+        let scrutinee_name = runtime_name_of_var state.env scrutinee in
+        let (constructor, arguments) = lookup_constructor runtime scrutinee_name in
+        let dup_names = lookup_runtime_names state.env (List.map (fun n -> (n, 1)) (VarSet.elements fvs)) in
+        Runtime.dup runtime dup_names;
+        Runtime.drop runtime [ (name, 1) ];
+        let extended_env = bind_many_rt lambda.parameters args closure_env in
+        finish_current { state with current_comp = lambda.body; env = extended_env }
+        *)
+        failwith "TODO"
+(*
+
+        (* FIXME: same Name-vs-Inject dereferencing gap as tuple_values_of_var above. *)
+        match force_var state.decls state.env scrutinee with
+        | RuntimeValue.Inject (tag, values) ->
+          begin
+            match List.find_opt (fun (_, _, name) -> String.equal name tag) branches with
+            | None ->
+              runtime_error
+                (Format.asprintf "No matching case branch for constructor '%s'" tag)
+            | Some (binders, branch_body, _) ->
+              if List.length binders <> List.length values then
+                runtime_error "Constructor arity mismatch in case expression";
+              let env' = bind_many_rt binders values state.env in
+              finish_current { state with current_comp = branch_body; env = env' }
+          end
+        | other ->
+          runtime_error
+            (Format.asprintf "Expected a data constructor for case analysis, got: %a" RuntimeValue.pp other)
       end
       *)
-
-    | New _ -> return state (WithIrMetadata.make <| Ir.Name (Runtime.new_mailbox runtime))
+    | New _ -> return state (Name (Runtime.new_mailbox runtime))
     | Send { target; message = (tag, payloads); iname = _ } ->
       let mb_name = runtime_name_of_value state.env target in
       let runtime_message = (tag, List.map (RuntimeValue.of_ir state.env) payloads) in
@@ -447,7 +490,7 @@ let rec step_current runtime state =
     | Guard { target; guards; _ } ->
       let mb_name = runtime_name_of_value state.env target in
       let tags = List.concat_map (fun g ->
-        match get_node g with
+        match g with
           | Receive recv -> [recv.tag]
           | _ -> []
         ) guards
@@ -459,17 +502,25 @@ let rec step_current runtime state =
             let env' =
               state.env
               |> bind_many_rt recv_guard.payload_binders rt_vals
-              |> bind recv_guard.mailbox_binder (WithIrMetadata.make (Name mb_name))
+              |> bind recv_guard.mailbox_binder (Name mb_name)
             in
             finish_current { state with env = env'; current_comp = recv_guard.cont } 
         | Freed ->
             let (bnd, cont) = find_empty_guard guards in
-            let env' = bind bnd (WithIrMetadata.make (Name mb_name)) state.env in
+            let env' = bind bnd (Name mb_name) state.env in
             finish_current { state with env = env'; current_comp = cont } 
       end
     | Free (target, _iname) ->
       let rt_name = runtime_name_of_value state.env target in
       Runtime.free_mailbox runtime rt_name;
+      return_unit state
+    | Dup vars ->
+      let names = lookup_runtime_names state.env vars in
+      Runtime.dup runtime names;
+      return_unit state
+    | Drop { vars; names } ->
+      let var_names = lookup_runtime_names state.env vars in
+      Runtime.drop runtime (var_names @ names);
       return_unit state
     | Spawn comp ->
       Runtime.spawn runtime

--- a/lib/interp/evaluation_ir.ml
+++ b/lib/interp/evaluation_ir.ml
@@ -23,6 +23,9 @@ and decl = {
     decl_parameters: Binder.t list;
     decl_body: comp
 }
+and function_target =
+    | PrimitiveFunction of string
+    | UserFunction of Var.t
 and comp =
     | Let of {
         binder: Binder.t;
@@ -32,7 +35,7 @@ and comp =
     | Seq of (comp * comp)
     | Return of value
     | App of {
-        func: Var.t;
+        func: function_target;
         args: value list
       }
     | If of { test: value; then_expr: comp; else_expr: comp }
@@ -128,8 +131,13 @@ and pp_comp ppf comp =
         fprintf ppf "(%a;@,%a)" pp_comp c1 pp_comp c2
     | Return v -> pp_value ppf v
     | App { func; args } ->
-        fprintf ppf "%a(%a)"
-            Var.pp func
+        let f_name =
+            match func with
+                | PrimitiveFunction f -> f
+                | UserFunction v -> Format.asprintf "%a" Var.pp v
+        in
+        fprintf ppf "%s(%a)"
+            f_name
             (pp_print_comma_list pp_value) args
     | If { test; then_expr; else_expr } ->
         fprintf ppf "if (%a) {@[<v>%a@]} else {@[<v>%a@]}}"

--- a/lib/interp/evaluation_ir.ml
+++ b/lib/interp/evaluation_ir.ml
@@ -12,6 +12,7 @@ open Util.Utility
 module Var = Ir.Var
 module Binder = Ir.Binder
 module RuntimeName = Ir.RuntimeName
+module VarSet = Ir.VarSet
 
 type program = {
     prog_decls: decl list;
@@ -75,6 +76,10 @@ and value =
     | Lam of lambda
 and lambda = {
     parameters: Binder.t list;
+    (* Free variables of the lambda as a whole, computed during reference counting.
+       Retained here so the runtime can drop a dying closure's captured refs without
+       having to recompute free variables by re-traversing the body. *)
+    fvs: VarSet.t;
     body: comp
 }
 and message_tag = string
@@ -197,7 +202,7 @@ and pp_value ppf value =
         fprintf ppf "%a" (pp_print_comma_list pp_value) vs
     | Inject (name, vs) ->
         fprintf ppf "%s(%a)" name (pp_print_comma_list pp_value) vs
-    | Lam { parameters; body } ->
+    | Lam { parameters; body; _ } ->
         fprintf ppf "fun(%a) {@,  @[<v>%a@]@,}"
             (pp_print_comma_list Binder.pp) parameters
             pp_comp body

--- a/lib/interp/evaluation_ir.ml
+++ b/lib/interp/evaluation_ir.ml
@@ -36,7 +36,7 @@ and comp =
     | Return of value
     | App of {
         func: function_target;
-        args: value list
+        args: Var.t list
       }
     | If of { test: value; then_expr: comp; else_expr: comp }
     | LetTuple of {
@@ -86,7 +86,7 @@ and lambda = {
     body: comp
 }
 and message_tag = string
-and message = (message_tag * value list)
+and message = (message_tag * Var.t list)
 and primitive_name = string
 and atom_name = string
 and constant = Constant.t
@@ -114,7 +114,7 @@ and pp_decl ppf { decl_name; decl_parameters; decl_body } =
 and pp_message ppf (tag, vs) =
     fprintf ppf "%s(%a)"
         tag
-        (pp_print_comma_list pp_value) vs
+        (pp_print_comma_list Var.pp) vs
 and pp_branch name ppf (bnds, c) =
     fprintf ppf "%s(%a) -> @[<v>%a@]"
         name
@@ -138,7 +138,7 @@ and pp_comp ppf comp =
         in
         fprintf ppf "%s(%a)"
             f_name
-            (pp_print_comma_list pp_value) args
+            (pp_print_comma_list Var.pp) args
     | If { test; then_expr; else_expr } ->
         fprintf ppf "if (%a) {@[<v>%a@]} else {@[<v>%a@]}}"
             pp_value test

--- a/lib/interp/evaluation_ir.ml
+++ b/lib/interp/evaluation_ir.ml
@@ -1,0 +1,215 @@
+(* IR used for evaluation: produced after typechecking (and reference counting) but before
+   interpretation. Structurally similar to Common.Ir, except:
+   - All type information (Type.t / Pretype.t) is discarded.
+   - App's function, Case's scrutinee, and LetTuple's source are variables, not arbitrary values.
+   - There's no per-node metadata (position / free variables). *)
+
+open Common
+open Common_types
+open Format
+open Util.Utility
+
+module Var = Ir.Var
+module Binder = Ir.Binder
+module RuntimeName = Ir.RuntimeName
+
+type program = {
+    prog_decls: decl list;
+    prog_body: comp option
+}
+and decl = {
+    decl_name: Binder.t;
+    decl_parameters: Binder.t list;
+    decl_body: comp
+}
+and comp =
+    | Let of {
+        binder: Binder.t;
+        term: comp;
+        cont: comp
+      }
+    | Seq of (comp * comp)
+    | Return of value
+    | App of {
+        func: Var.t;
+        args: value list
+      }
+    | If of { test: value; then_expr: comp; else_expr: comp }
+    | LetTuple of {
+        binders: Binder.t list;
+        tuple: Var.t;
+        cont: comp
+    }
+    | Case of {
+        scrutinee: Var.t;
+        branches: (Binder.t list * comp * string) list
+    }
+    | New of string
+    | Spawn of comp
+    | Send of {
+        target: value;
+        message: message;
+        iname: string
+      }
+    | Free of (value * string)
+    | Guard of {
+        target: value;
+        pattern: Type.Pattern.t;
+        guards: guard list;
+        iname: string
+      }
+    (* Reference counting instructions inserted after typechecking *)
+    | Drop of {
+            vars: (Var.t * int) list;
+            names: (RuntimeName.t * int) list
+        }
+    | Dup of (Var.t * int) list
+and value =
+    | Atom of atom_name
+    | Constant of constant
+    | Primitive of primitive_name
+    | Variable of Var.t
+    | Name of RuntimeName.t
+    | Tuple of value list
+    | Inject of string * value list
+    | Lam of lambda
+and lambda = {
+    parameters: Binder.t list;
+    body: comp
+}
+and message_tag = string
+and message = (message_tag * value list)
+and primitive_name = string
+and atom_name = string
+and constant = Constant.t
+and guard =
+    | Receive of receive_guard
+    | Empty of (Binder.t * comp)
+    | Fail
+and receive_guard = {
+        tag: string;
+        payload_binders: Binder.t list;
+        mailbox_binder: Binder.t;
+        cont: comp
+    }
+
+(* Pretty-printing of the evaluation IR *)
+let rec pp_program ppf { prog_decls; prog_body } =
+    fprintf ppf "%a@.@.%a"
+        (pp_print_double_newline_list pp_decl) prog_decls
+        (pp_print_option pp_comp) prog_body
+and pp_decl ppf { decl_name; decl_parameters; decl_body } =
+    fprintf ppf "def %a(%a) {@,@[<v 2>  %a@]@,}"
+        Binder.pp decl_name
+        (pp_print_comma_list Binder.pp) decl_parameters
+        pp_comp decl_body
+and pp_message ppf (tag, vs) =
+    fprintf ppf "%s(%a)"
+        tag
+        (pp_print_comma_list pp_value) vs
+and pp_branch name ppf (bnds, c) =
+    fprintf ppf "%s(%a) -> @[<v>%a@]"
+        name
+        (pp_print_comma_list Binder.pp) bnds
+        pp_comp c
+and pp_comp ppf comp =
+    match comp with
+    | Let { binder; term; cont } ->
+        fprintf ppf "let %a = @[<v>%a@] in@,%a"
+            Binder.pp binder
+            pp_comp term
+            pp_comp cont
+    | Seq (c1, c2) ->
+        fprintf ppf "(%a;@,%a)" pp_comp c1 pp_comp c2
+    | Return v -> pp_value ppf v
+    | App { func; args } ->
+        fprintf ppf "%a(%a)"
+            Var.pp func
+            (pp_print_comma_list pp_value) args
+    | If { test; then_expr; else_expr } ->
+        fprintf ppf "if (%a) {@[<v>%a@]} else {@[<v>%a@]}}"
+            pp_value test
+            pp_comp then_expr
+            pp_comp else_expr
+    | LetTuple { binders; tuple; cont } ->
+        fprintf ppf "let %a = @[<v>%a@] in@,%a"
+            (pp_print_comma_list Binder.pp) binders
+            Var.pp tuple
+            pp_comp cont
+    | Case { scrutinee; branches } ->
+        fprintf ppf
+            "case %a of {@[<v>%a@]}"
+            Var.pp scrutinee
+            (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf "@,")
+                (fun ppf (bnds, c, name) -> pp_branch name ppf (bnds, c))) branches
+    | New iname -> fprintf ppf "new[%s]" iname
+    | Spawn e -> fprintf ppf "spawn {@[<v>@,%a@]@,}" pp_comp e
+    | Send { target; message; iname = _ } ->
+        (* Special-case the common case of sending to a variable.
+           Bracket the rest for readability. *)
+        begin
+            match target with
+                | Variable _ ->
+                    fprintf ppf "%a ! %a"
+                        pp_value target
+                        pp_message message
+                | _ ->
+                    fprintf ppf "(@[<v 2>%a@]) ! %a"
+                        pp_value target
+                        pp_message message
+        end
+    | Free (v, _iname) ->
+        fprintf ppf "free(%a)" pp_value v
+    | Guard { target; pattern; guards; _ } ->
+        fprintf ppf
+            "guard %a : %a {@,@[<v 2>  %a@]@,}"
+            pp_value target
+            Type.Pattern.pp pattern
+            (pp_print_newline_list pp_guard) guards
+    | Drop { vars; names } ->
+        let pp_var ppf (var, count) = fprintf ppf "\"%s\":%d" (Var.unique_name var) count in
+        let pp_name ppf (name, count) = fprintf ppf "\"%a\":%d" RuntimeName.pp name count in
+        begin
+            match (vars, names) with
+            | (_, []) ->
+                fprintf ppf "drop (%a)"
+                    (pp_print_comma_list pp_var) vars
+            | ([], _) ->
+                fprintf ppf "drop_names (%a)"
+                    (pp_print_comma_list pp_name) names
+            | _ ->
+                fprintf ppf "drop (vars=[%a], names=[%a])"
+                    (pp_print_comma_list pp_var) vars
+                    (pp_print_comma_list pp_name) names
+        end
+    | Dup vars ->
+        let pp_var ppf (var, count) = fprintf ppf "\"%s\":%d" (Var.unique_name var) count in
+        fprintf ppf "dup (%a)"
+            (pp_print_comma_list pp_var) vars
+and pp_value ppf value =
+    match value with
+    | Atom name -> Format.pp_print_string ppf (":" ^ name)
+    | Primitive prim -> Format.pp_print_string ppf prim
+    | Variable var -> Var.pp ppf var
+    | Name runtime_name -> RuntimeName.pp ppf runtime_name
+    | Constant c -> Constant.pp ppf c
+    | Tuple vs ->
+        fprintf ppf "%a" (pp_print_comma_list pp_value) vs
+    | Inject (name, vs) ->
+        fprintf ppf "%s(%a)" name (pp_print_comma_list pp_value) vs
+    | Lam { parameters; body } ->
+        fprintf ppf "fun(%a) {@,  @[<v>%a@]@,}"
+            (pp_print_comma_list Binder.pp) parameters
+            pp_comp body
+and pp_guard ppf guard =
+    match guard with
+    | Receive { tag; payload_binders; mailbox_binder; cont } ->
+            fprintf ppf "receive %s(%a) from %a ->@,@[<v 2>  %a@]"
+            tag
+            (pp_print_comma_list Binder.pp) payload_binders
+            Binder.pp mailbox_binder
+            pp_comp cont
+    | Empty (x, e) ->
+        fprintf ppf "empty(%a) ->@,  @[<v>%a@]" Binder.pp x pp_comp e
+    | Fail ->
+        fprintf ppf "fail"

--- a/lib/interp/evaluation_ir.ml
+++ b/lib/interp/evaluation_ir.ml
@@ -79,9 +79,6 @@ and value =
     | Lam of lambda
 and lambda = {
     parameters: Binder.t list;
-    (* Free variables of the lambda as a whole, computed during reference counting.
-       Retained here so the runtime can drop a dying closure's captured refs without
-       having to recompute free variables by re-traversing the body. *)
     fvs: VarSet.t;
     body: comp
 }

--- a/lib/interp/evaluation_ir.ml
+++ b/lib/interp/evaluation_ir.ml
@@ -71,8 +71,8 @@ and value =
     | Primitive of primitive_name
     | Variable of Var.t
     | Name of RuntimeName.t
-    | Tuple of value list
-    | Inject of string * value list
+    | Tuple of Var.t list
+    | Inject of string * Var.t list
     | Lam of lambda
 and lambda = {
     parameters: Binder.t list;
@@ -199,9 +199,9 @@ and pp_value ppf value =
     | Name runtime_name -> RuntimeName.pp ppf runtime_name
     | Constant c -> Constant.pp ppf c
     | Tuple vs ->
-        fprintf ppf "%a" (pp_print_comma_list pp_value) vs
+        fprintf ppf "%a" (pp_print_comma_list Var.pp) vs
     | Inject (name, vs) ->
-        fprintf ppf "%s(%a)" name (pp_print_comma_list pp_value) vs
+        fprintf ppf "%s(%a)" name (pp_print_comma_list Var.pp) vs
     | Lam { parameters; body; _ } ->
         fprintf ppf "fun(%a) {@,  @[<v>%a@]@,}"
             (pp_print_comma_list Binder.pp) parameters

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -303,18 +303,26 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
         | New interface ->
             Evaluation_ir.New interface
         | Spawn e ->
-            (* We need any reference counting that's done inside the expression
-               to happen in the parent thread, **not** the spawned thread. Otherwise we end up
-               with a concurrency bug: required duplications will be deferred until the 
-               spawned thread is scheduled. By hoisting any duplications to the parent thread we
-               ensure the continuation is evaluated in a consistent state regardless of scheduling. *)
-            let counted_body = irc borrowed owned e in
-            begin
-                match counted_body with
-                    | Evaluation_ir.Seq ((Evaluation_ir.Dup _ as dup_node), e2) ->
-                        Evaluation_ir.Seq (dup_node, Evaluation_ir.Spawn e2)
-                    | _ -> Evaluation_ir.Spawn counted_body
-            end
+            (* Any duplication the spawned body needs from the enclosing scope has to
+               happen in the parent thread, **not** the spawned thread. Otherwise we end
+               up with a concurrency bug: the duplication is deferred until the spawned
+               thread is first scheduled, and the parent may consume its own reference
+               before that happens.
+
+               Rather than trying to spot dups in the translated body (which only works
+               when one lands at the very front of it), we transfer ownership up-front:
+               everything the body uses that we borrow is dup'd here, and the body
+               is then translated with those variables owned, so it generates no dups for
+               them itself. *)
+            let body_fvs = get_fvs e in
+            let transferred = VarSet.inter borrowed body_fvs in
+            (* Owned variables are moved into the body wholesale; the invariant on [owned]
+               guarantees they are all free in it. *)
+            let body_owned = VarSet.union owned transferred in
+            let body_borrowed = VarSet.diff borrowed transferred in
+            let counted_body = irc body_borrowed body_owned e in
+            let dups = VarSet.elements transferred |> List.map (fun v -> (v, 1)) in
+            insert_dup dups (Evaluation_ir.Spawn counted_body)
         | Send { target; message = (tag, message_values); iname } -> 
             begin
                 match transform_val_sequence decls borrowed owned (target :: message_values) with

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -98,7 +98,13 @@ and let_insert (comp : comp) : comp =
             let fvs = fvs_with_bindings comp bindings in
             insert_let_bindings fvs bindings (WithIrMetadata.make ~fvs (Return v'))
         | App { func; args } ->
-            let (func_bindings, func') = force_variable func in
+            let (func_bindings, func') =
+                begin
+                    match WithIrMetadata.node func with
+                    | Primitive p -> ([], WithIrMetadata.make (Primitive p))
+                    | _ -> force_variable func
+                end
+            in
             let (args_bindings, args') = let_bind_value_list args in
             let bindings = func_bindings @ args_bindings in
             let fvs = fvs_with_bindings comp bindings in
@@ -208,9 +214,14 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
             insert_dup dups (Evaluation_ir.Return v')
         | App { func; args } ->
             (* func is guaranteed a bare variable post let-insertion *)
-            let func_var = unwrap_var (WithIrMetadata.node func) in
+            let func_target =
+                match WithIrMetadata.node func with
+                    | Variable (v, _) -> Evaluation_ir.UserFunction v
+                    | Primitive p -> Evaluation_ir.PrimitiveFunction p
+                    | _ -> assert false (* FIXME: more informative error*)
+            in 
             let (dups, args') = transform_val_sequence decls borrowed owned args in
-            insert_dup (VarMultiset.bindings dups) (Evaluation_ir.App { func = func_var; args = args' })
+            insert_dup (VarMultiset.bindings dups) (Evaluation_ir.App { func = func_target; args = args' })
         (* When doing branching control flow: when processing each subexpression, owned environment is the
               intersection of the current owned environment and the free variables of the subexpression.
               Then in the body, drop everything that is in the owned environment but not the current environment.

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -146,9 +146,68 @@ let rec insert_reference_counting_comp decls borrowed owned comp =
                 WithIrMetadata.make ~fvs (LetTuple { binders; tuple = translated_tuple; cont = final_translated_cont })
             in
             Ir.insert_dup dups translated_let_tuple
-        (* SJF TODO: Implement this for the general ADT case *)
-        | Case _ ->
-            raise <| Errors.internal_error "reference_counting.ml" "Evaluating case-expressions not yet supported"
+        | Case { term; ty; branches } ->
+            let mk_drop vars transformed_comp =
+                let var_list =
+                    VarSet.elements vars
+                    |> List.map (fun v -> (v, 1))
+                in
+                let drop = WithIrMetadata.make ~fvs:vars (Drop { vars = var_list; names = [] }) in
+                WithIrMetadata.make ~fvs:vars (Seq (drop, transformed_comp))
+            in
+            (* The owned set of each branch is the owned environment overall,
+               extended with bound vars, intersected with FVs of body*)
+            (* Collect all envs along with transformed (incl. drops) bodies *)
+            let transformed_branches_with_envs =
+                List.map (fun (params, comp, constr)  ->
+                    let params_vars = List.map Var.of_binder params |> VarSet.of_list in
+                    let owned_with_params = VarSet.union owned params_vars in
+                    let comp_owned =
+                        VarSet.inter
+                            owned_with_params
+                            (WithIrMetadata.fvs comp)
+                    in
+                    let to_drop = VarSet.diff owned_with_params comp_owned in
+                    let transformed_comp =
+                        mk_drop 
+                            to_drop
+                            (irc borrowed comp_owned comp)
+                    in
+                    (comp_owned, (params, transformed_comp, constr))
+                ) branches
+            in
+            let (transformed_branches_envs, transformed_branches_bodies) =
+                List.split transformed_branches_with_envs
+            in
+            (* Union of all variables required to type branches
+                (thus must be borrowed when typing subject) *)
+            let all_branches_owned =
+                VarSet.union_many transformed_branches_envs
+            in
+            let borrowed_subj = VarSet.union borrowed all_branches_owned in
+            let owned_subj = VarSet.diff owned borrowed_subj in
+            let (dups, translated_term) = ircv borrowed_subj owned_subj term in
+            (* Get union of all FVs in each branch (used for calculating overall term FVs) *)
+            let branches_fvs =
+                List.map (fun (params, comp, _) ->
+                    List.map Var.of_binder params
+                    |> VarSet.of_list
+                    |> VarSet.diff (WithIrMetadata.fvs comp)) transformed_branches_bodies
+                    |> VarSet.union_many
+            in
+            let translated_case_fvs =
+                VarSet.union
+                    (get_fvs translated_term)
+                    branches_fvs
+            in
+            let translated_case =
+                WithIrMetadata.make ~fvs:translated_case_fvs (Case {
+                    term = translated_term;
+                    branches = transformed_branches_bodies;
+                    ty
+                })
+            in
+            Ir.insert_dup dups translated_case
             (*
         | Case { term; branch1 = ((bnd1, ty1), e1); branch2 = ((bnd2, ty2), e2) } ->
             let bnd1_var = Var.of_binder bnd1 in
@@ -317,8 +376,10 @@ and insert_reference_counting_val decls borrowed owned value =
         | Primitive _
         | Name _ ->
             (VarMultiset.empty, value)
-        | Inject (_s, _vs) ->
-            raise <| Errors.internal_error "reference_counting.ml" "Evaluating ADTs not yet supported"
+        | Inject (s, vs) ->
+            let (dups, vs') = transform_val_sequence decls borrowed owned vs in 
+            let fvs = List.fold_left (fun acc v -> VarSet.union acc (get_fvs v)) VarSet.empty vs' in
+            (dups, WithIrMetadata.make ~fvs (Inject (s, vs')))
         | Variable (x, _) ->
             if VarSet.mem x owned || VarSet.mem x decl_vars then
               (* Owned or global declaration -- no dup needed *)

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -11,7 +11,76 @@ let pp_varset ppf s =
     VarSet.iter (fun v -> Format.fprintf ppf "%a " Var.pp v) s;
     Format.pp_print_string ppf "}"
 
-let rec insert_reference_counting_comp decls borrowed owned comp =
+
+(* Let-insertion: ensures the subject of a Case, LetTuple, or function
+   application is always a bare variable, hoisting it into a fresh
+   let-binding otherwise. Required before reference counting / evaluation
+   in order to better support Perceus heap semantics. Also simplifies the pass. *)
+let bind_subject (comp : comp) (subject : value) (rest_fvs : varset) (rebuild : value -> comp_node) : comp =
+    match WithIrMetadata.node subject with
+        | Variable _ -> comp
+        | _ ->
+            let binder = Binder.make () in
+            let var = Var.of_binder binder in
+            let var_val = WithIrMetadata.make ~fvs:(VarSet.singleton var) (Variable (var, None)) in
+            let term = WithIrMetadata.make ~fvs:(get_fvs subject) (Return subject) in
+            let cont = WithIrMetadata.make ~fvs:(VarSet.add var rest_fvs) (rebuild var_val) in
+            { comp with node = Let { binder; term; cont } }
+
+let let_insert : comp -> comp =
+    let visitor =
+        object
+            inherit [_] Ir.map as super
+
+            method! visit_comp env comp =
+                let comp = super#visit_comp env comp in
+                match WithIrMetadata.node comp with
+                    | App { func; args } ->
+                        let rest_fvs = List.fold_left (fun acc a -> VarSet.union acc (get_fvs a)) VarSet.empty args in
+                        bind_subject comp func rest_fvs (fun func -> App { func; args })
+                    | LetTuple { binders; tuple; cont } ->
+                        let bnd_vars = binders |> List.map (fun (b, _) -> Var.of_binder b) |> VarSet.of_list in
+                        let rest_fvs = VarSet.diff (get_fvs cont) bnd_vars in
+                        bind_subject comp tuple rest_fvs (fun tuple -> LetTuple { binders; tuple; cont })
+                    | Case { term; ty; branches } ->
+                        let rest_fvs =
+                            branches
+                            |> List.map (fun (params, body, _) ->
+                                let bound_vars = List.map Var.of_binder params |> VarSet.of_list in
+                                VarSet.diff (get_fvs body) bound_vars)
+                            |> VarSet.union_many
+                        in
+                        bind_subject comp term rest_fvs (fun term -> Case { term; ty; branches })
+                    | _ -> comp
+
+            method visit_t _env x = x
+        end
+    in
+    visitor#visit_comp ()
+
+let unwrap_var = function
+    | Variable (v, _) -> v
+    | _ -> raise <| Errors.internal_error "reference_counting.ml" "Tried to unwrap non-variable."
+
+let insert_dup (dups : (Var.t * int) list) (comp : Evaluation_ir.comp) : Evaluation_ir.comp =
+    let open Evaluation_ir in
+    if List.is_empty dups then
+        comp
+    else
+        Seq (Dup dups, comp)
+
+let insert_drop ?(names = []) (drops : (Var.t * int) list) (comp : Evaluation_ir.comp) : Evaluation_ir.comp =
+    let open Evaluation_ir in
+    if List.is_empty drops && List.is_empty names then
+        comp
+    else
+        Seq (Drop { vars = drops; names }, comp)
+
+
+let mk_var_drop vars comp =
+    insert_drop (VarSet.elements vars |> List.map (fun v -> (v, 1))) comp
+
+let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir.comp =
     let irc = insert_reference_counting_comp decls in
     let ircv borrowed owned v = 
         let (dups, v') = insert_reference_counting_val decls borrowed owned v in
@@ -19,33 +88,22 @@ let rec insert_reference_counting_comp decls borrowed owned comp =
     in
     let ircg borrowed guards_owned g = insert_reference_counting_guard decls borrowed guards_owned g in
     match WithIrMetadata.node comp with
-        | Annotate (c, ty) ->
-            let c' = irc borrowed owned c in
-            let fvs = get_fvs c' in
-            WithIrMetadata.make ~fvs (Annotate (c', ty))
+        | Annotate (c, _ty) ->
+            (* Evaluation_ir discards type annotations entirely *)
+            irc borrowed owned c
         | Let { binder; term; cont } ->
             let binder_var = Var.of_binder binder in
             let cont_fvs = get_fvs cont in
             let e2_owned = VarSet.(inter owned (diff cont_fvs (singleton binder_var))) in
             let e1_owned = VarSet.diff owned e2_owned in
             let e1_trans = irc borrowed e1_owned term in
+            let e2_trans = irc borrowed (VarSet.(union e2_owned (singleton binder_var))) cont in
             (* Insert a drop if binder is unused in e2 *)
             if VarSet.mem binder_var cont_fvs then
-                let e2_trans = irc borrowed (VarSet.(union e2_owned (singleton binder_var))) cont in
-                let fvs = VarSet.union (get_fvs e1_trans) (get_fvs e2_trans) in
-                WithIrMetadata.make ~fvs (Let { binder; term = e1_trans; cont = e2_trans })
+                Evaluation_ir.Let { binder; term = e1_trans; cont = e2_trans }
             else
-                let e2_trans = irc borrowed (VarSet.(union e2_owned (singleton binder_var))) cont in
-                let drop_node =
-                    WithIrMetadata.make ~fvs:(VarSet.singleton binder_var)
-                        (Drop { vars = [ (binder_var, 1) ]; names = [] })
-                in
-                let e2_trans_with_drop = 
-                    let fvs = VarSet.union (get_fvs drop_node) (get_fvs e2_trans) in
-                    WithIrMetadata.make ~fvs (Seq (drop_node, e2_trans))
-                in
-                let fvs = VarSet.union (get_fvs e1_trans) (get_fvs e2_trans_with_drop) in
-                WithIrMetadata.make ~fvs (Let { binder; term = e1_trans; cont = e2_trans_with_drop })
+                let e2_trans_with_drop = insert_drop [ (binder_var, 1) ] e2_trans in
+                Evaluation_ir.Let { binder; term = e1_trans; cont = e2_trans_with_drop }
         | Seq (e1, e2) ->
             (* e2_owned : owned environment of e2. Calculated by the intersection of owned environment and FVs of e2. *)
             let e2_owned = VarSet.inter owned (get_fvs e2) in
@@ -57,22 +115,15 @@ let rec insert_reference_counting_comp decls borrowed owned comp =
             let e2_borrowed = borrowed in
             let e1' = irc e1_borrowed e1_owned e1 in
             let e2' = irc e2_borrowed e2_owned e2 in
-            let fvs = VarSet.union (get_fvs e1') (get_fvs e2') in
-            WithIrMetadata.make ~fvs (Seq (e1', e2'))
+            Evaluation_ir.Seq (e1', e2')
         | Return v ->
             let (dups, v') = ircv borrowed owned v in
-            let return_node = WithIrMetadata.make ~fvs:(get_fvs v') (Return v') in
-            Ir.insert_dup dups return_node
+            insert_dup dups (Evaluation_ir.Return v')
         | App { func; args } ->
-            begin
-                match transform_val_sequence decls borrowed owned (func :: args) with
-                    | (dups, func' :: args') ->
-                        let dups_list = VarMultiset.bindings dups in
-                        let fvs = List.fold_left (fun acc v -> VarSet.union acc (get_fvs v)) VarSet.empty (func' :: args') in
-                        Ir.insert_dup dups_list (WithIrMetadata.make ~fvs (App { func = func'; args = args' }))
-                    (* impossible; transform_val_sequence always gives the same number of values back *)
-                    | _ -> assert false
-            end
+            (* func is guaranteed a bare variable post let-insertion *)
+            let func_var = unwrap_var (WithIrMetadata.node func) in
+            let (dups, args') = transform_val_sequence decls borrowed owned args in
+            insert_dup (VarMultiset.bindings dups) (Evaluation_ir.App { func = func_var; args = args' })
         (* When doing branching control flow: when processing each subexpression, owned environment is the
               intersection of the current owned environment and the free variables of the subexpression.
               Then in the body, drop everything that is in the owned environment but not the current environment.
@@ -85,14 +136,6 @@ let rec insert_reference_counting_comp decls borrowed owned comp =
                 (VarSet.union
                     (get_fvs then_expr)
                     (get_fvs else_expr)) in
-            let mk_drop vars cont =
-                let var_list =
-                    vars
-                    |> VarSet.elements
-                    |> List.map (fun v -> (v, 1))
-                in
-                Ir.insert_drop var_list cont
-            in
             (* Drop everything in the branches_owned set that is not in the current *)
             let test_borrowed = VarSet.union borrowed branches_owned in
             let test_owned = VarSet.diff owned branches_owned in
@@ -103,15 +146,13 @@ let rec insert_reference_counting_comp decls borrowed owned comp =
             let translated_then = irc borrowed then_owned then_expr in
             let translated_else = irc borrowed else_owned else_expr in
 
-            let final_then_expr = mk_drop (VarSet.diff branches_owned then_owned) translated_then in
-            let final_else_expr = mk_drop (VarSet.diff branches_owned else_owned) translated_else in
-            let fvs = VarSet.union (get_fvs translated_test) (VarSet.union (get_fvs final_then_expr) (get_fvs final_else_expr)) in
-            let translated_if = 
-                WithIrMetadata.make ~fvs (If { 
-                    test = translated_test; then_expr = final_then_expr; else_expr = final_else_expr })
-            in
-            Ir.insert_dup dups translated_if
+            let final_then_expr = mk_var_drop (VarSet.diff branches_owned then_owned) translated_then in
+            let final_else_expr = mk_var_drop (VarSet.diff branches_owned else_owned) translated_else in
+            insert_dup dups
+                (Evaluation_ir.If { test = translated_test; then_expr = final_then_expr; else_expr = final_else_expr })
         | LetTuple { binders; tuple; cont } ->
+            (* tuple is guaranteed a bare variable post let-insertion *)
+            let tuple_var = unwrap_var (WithIrMetadata.node tuple) in
             let cont_fvs = get_fvs cont in
             let binders_set = 
                 binders
@@ -125,40 +166,22 @@ let rec insert_reference_counting_comp decls borrowed owned comp =
             in
             (* cont_drop: everything in binders that isn't used in cont *)
             let cont_drop = VarSet.diff binders_set cont_fvs in
-            let tuple_borrowed = VarSet.union borrowed cont_owned in
-            let tuple_owned = VarSet.diff owned tuple_borrowed in
-            let (dups, translated_tuple) = ircv tuple_borrowed tuple_owned tuple in
             let translated_cont =  irc borrowed cont_owned cont in
-            let final_translated_cont = 
-                if VarSet.is_empty cont_drop then
-                    translated_cont
-                else
-                    (* Drop binders if variables unused *)
-                    let drop_node =
-                        WithIrMetadata.make ~fvs:cont_drop
-                            (Drop { vars = (VarSet.to_list cont_drop |> List.map (fun v -> (v, 1))); names = [] })
-                    in
-                    let fvs = VarSet.union (get_fvs drop_node) (get_fvs translated_cont) in
-                    WithIrMetadata.make ~fvs (Seq (drop_node, translated_cont))
-                in
-            let translated_let_tuple =
-                let fvs = VarSet.union (get_fvs translated_tuple) (get_fvs final_translated_cont) in
-                WithIrMetadata.make ~fvs (LetTuple { binders; tuple = translated_tuple; cont = final_translated_cont })
-            in
-            Ir.insert_dup dups translated_let_tuple
-        | Case { term; ty; branches } ->
+            let final_translated_cont = mk_var_drop cont_drop translated_cont in
+            Evaluation_ir.LetTuple { binders = List.map fst binders; tuple = tuple_var; cont = final_translated_cont }
+        | Case { term; branches; _ } ->
+            let var = unwrap_var (WithIrMetadata.node term) in
             let mk_drop vars transformed_comp =
                 let var_list =
                     VarSet.elements vars
                     |> List.map (fun v -> (v, 1))
                 in
-                let drop = WithIrMetadata.make ~fvs:vars (Drop { vars = var_list; names = [] }) in
-                WithIrMetadata.make ~fvs:vars (Seq (drop, transformed_comp))
+                insert_drop var_list transformed_comp
             in
             (* The owned set of each branch is the owned environment overall,
                extended with bound vars, intersected with FVs of body*)
             (* Collect all envs along with transformed (incl. drops) bodies *)
-            let transformed_branches_with_envs =
+            let transformed_branches =
                 List.map (fun (params, comp, constr)  ->
                     let params_vars = List.map Var.of_binder params |> VarSet.of_list in
                     let owned_with_params = VarSet.union owned params_vars in
@@ -173,102 +196,12 @@ let rec insert_reference_counting_comp decls borrowed owned comp =
                             to_drop
                             (irc borrowed comp_owned comp)
                     in
-                    (comp_owned, (params, transformed_comp, constr))
+                    (params, transformed_comp, constr)
                 ) branches
             in
-            let (transformed_branches_envs, transformed_branches_bodies) =
-                List.split transformed_branches_with_envs
-            in
-            (* Union of all variables required to type branches
-                (thus must be borrowed when typing subject) *)
-            let all_branches_owned =
-                VarSet.union_many transformed_branches_envs
-            in
-            let borrowed_subj = VarSet.union borrowed all_branches_owned in
-            let owned_subj = VarSet.diff owned borrowed_subj in
-            let (dups, translated_term) = ircv borrowed_subj owned_subj term in
-            (* Get union of all FVs in each branch (used for calculating overall term FVs) *)
-            let branches_fvs =
-                List.map (fun (params, comp, _) ->
-                    List.map Var.of_binder params
-                    |> VarSet.of_list
-                    |> VarSet.diff (WithIrMetadata.fvs comp)) transformed_branches_bodies
-                    |> VarSet.union_many
-            in
-            let translated_case_fvs =
-                VarSet.union
-                    (get_fvs translated_term)
-                    branches_fvs
-            in
-            let translated_case =
-                WithIrMetadata.make ~fvs:translated_case_fvs (Case {
-                    term = translated_term;
-                    branches = transformed_branches_bodies;
-                    ty
-                })
-            in
-            Ir.insert_dup dups translated_case
-            (*
-        | Case { term; branch1 = ((bnd1, ty1), e1); branch2 = ((bnd2, ty2), e2) } ->
-            let bnd1_var = Var.of_binder bnd1 in
-            let bnd2_var = Var.of_binder bnd2 in
-            let e1_fvs = get_fvs e1 in
-            let e2_fvs = get_fvs e2 in
-            let e1_owned = VarSet.inter (VarSet.union owned (VarSet.singleton bnd1_var)) e1_fvs in
-            let e2_owned = VarSet.inter (VarSet.union owned (VarSet.singleton bnd2_var)) e2_fvs in
-            let e1_owned_without_binder = VarSet.diff e1_owned (VarSet.singleton bnd1_var) in
-            let e2_owned_without_binder = VarSet.diff e2_owned (VarSet.singleton bnd2_var) in
-            (* branches_owned: all owned variables occurring in either branch *)
-            let branches_owned =
-                VarSet.inter owned (VarSet.union e1_owned_without_binder e2_owned_without_binder)
-            in
-            let mk_drop vars =
-                let var_list =
-                    VarSet.elements vars
-                    |> List.map (fun v -> (v, 1))
-                in
-                WithIrMetadata.make ~fvs:vars (Drop { vars = var_list; names = [] })
-            in
-            (* ei_drop: variables owned by branches (+binder), but not used. 
-               ensures variables are dropped if they're not used in that branch. *)
-            let e1_drop = mk_drop (
-                VarSet.diff 
-                    (VarSet.union branches_owned (VarSet.singleton (Var.of_binder bnd1)))
-                    e1_owned
-            )
-            in
-            let e2_drop = mk_drop (
-                VarSet.diff 
-                    (VarSet.union branches_owned (VarSet.singleton (Var.of_binder bnd2)))
-                    e2_owned
-            )
-            in
-            (* borrowed variables for the term: borrowed variables + variables used in branches *)
-            let term_borrowed = VarSet.union borrowed branches_owned in
-            let term_owned = VarSet.diff owned branches_owned in
-            let (dups, translated_term) = ircv term_borrowed term_owned term in
-            let translated_e1 = irc borrowed e1_owned e1 in
-            let translated_e2 = irc borrowed e2_owned e2 in
-            let final_e1_fvs = VarSet.union (get_fvs e1_drop) (get_fvs translated_e1) in
-            let final_e2_fvs = VarSet.union (get_fvs e2_drop) (get_fvs translated_e2) in
-            let final_e1 =
-                WithIrMetadata.make ~fvs:final_e1_fvs (Seq (e1_drop, translated_e1))
-            in
-            let final_e2 =
-                WithIrMetadata.make ~fvs:final_e2_fvs (Seq (e2_drop, translated_e2))
-            in
-            let translated_case_fvs = VarSet.union (get_fvs translated_term) (VarSet.union (get_fvs final_e1) (get_fvs final_e2)) in
-            let translated_case =
-                WithIrMetadata.make ~fvs:translated_case_fvs (Case {
-                    term = translated_term;
-                    branch1 = ((bnd1, ty1), final_e1);
-                    branch2 = ((bnd2, ty2), final_e2)
-                })
-            in
-            Ir.insert_dup dups translated_case
-            *)
+            Evaluation_ir.Case { scrutinee = var; branches = transformed_branches }
         | New interface ->
-            WithIrMetadata.make ~fvs:VarSet.empty (New interface)
+            Evaluation_ir.New interface
         | Spawn e ->
             (* We need any reference counting that's done inside the expression
                to happen in the parent thread, **not** the spawned thread. Otherwise we end up
@@ -276,32 +209,24 @@ let rec insert_reference_counting_comp decls borrowed owned comp =
                spawned thread is scheduled. By hoisting any duplications to the parent thread we
                ensure the continuation is evaluated in a consistent state regardless of scheduling. *)
             let counted_body = irc borrowed owned e in
-            let unchanged = WithIrMetadata.make ~fvs:(get_fvs counted_body) (Spawn counted_body) in
             begin
-                match WithIrMetadata.node counted_body with
-                    | Seq (e1, e2) ->
-                        begin match WithIrMetadata.node e1 with
-                            | Dup _dups ->
-                                let spawn_fvs = get_fvs e2 in
-                                WithIrMetadata.make ~fvs:(VarSet.union (get_fvs e1) spawn_fvs) (Seq (e1, WithIrMetadata.make ~fvs:spawn_fvs (Spawn e2)))
-                            | _ -> unchanged
-                        end
-                    | _ -> unchanged
+                match counted_body with
+                    | Evaluation_ir.Seq ((Evaluation_ir.Dup _ as dup_node), e2) ->
+                        Evaluation_ir.Seq (dup_node, Evaluation_ir.Spawn e2)
+                    | _ -> Evaluation_ir.Spawn counted_body
             end
         | Send { target; message = (tag, message_values); iname } -> 
             begin
                 match transform_val_sequence decls borrowed owned (target :: message_values) with
                     | (dups, target' :: message_values') ->
-                        let dups_list = VarMultiset.bindings dups in
-                        let fvs = List.fold_left (fun acc v -> VarSet.union acc (get_fvs v)) VarSet.empty (target' :: message_values') in
-                        Ir.insert_dup dups_list
-                            (WithIrMetadata.make ~fvs (Send { target = target'; message = (tag, message_values'); iname }))
+                        insert_dup (VarMultiset.bindings dups)
+                            (Evaluation_ir.Send { target = target'; message = (tag, message_values'); iname = Option.get iname })
                     (* impossible; transform_val_sequence always gives the same number of values back *)
                     | _ -> assert false
             end
         | Free (v, iname) ->
             let (dups, v') = ircv borrowed owned v in
-            Ir.insert_dup dups (WithIrMetadata.make ~fvs:(get_fvs v') (Free (v', iname)))
+            insert_dup dups (Evaluation_ir.Free (v', Option.get iname))
         | Guard { target; pattern; guards; iname } ->
             let guards_fvs =
                 List.fold_left
@@ -314,11 +239,8 @@ let rec insert_reference_counting_comp decls borrowed owned comp =
             let target_owned = VarSet.diff owned guards_owned in
             let (dups, translated_target) = ircv target_borrowed target_owned target in
             let translated_guards = List.map (ircg borrowed guards_owned) guards in
-            let guard_fvs = List.fold_left (fun acc g -> VarSet.union acc (get_fvs g)) (get_fvs translated_target) translated_guards in
-            let translated_guard =
-                WithIrMetadata.make ~fvs:guard_fvs (Guard { target = translated_target; pattern; guards = translated_guards; iname })
-            in
-            Ir.insert_dup dups translated_guard
+            insert_dup dups
+                (Evaluation_ir.Guard { target = translated_target; pattern; guards = translated_guards; iname = Option.get iname })
         | Drop _
         | Dup _ -> raise <| 
             Errors.internal_error
@@ -363,34 +285,31 @@ However this doesn't work because we can only send syntactic values. Instead we'
   x ! M(y); guard y { ... }
 It's not as exactly local as Perceus but it's safe.
 *)
-and insert_reference_counting_val decls borrowed owned value =
+and insert_reference_counting_val decls borrowed owned value : VarMultiset.t * Evaluation_ir.value =
     let decl_vars =
         decls |> List.map Var.of_binder |> VarSet.of_list
     in
     match WithIrMetadata.node value with
-        | VAnnotate (v, ty) ->
-            let (dups, v) = insert_reference_counting_val decls borrowed owned v in
-            (dups, WithIrMetadata.make ~fvs:(get_fvs v) (VAnnotate (v, ty)))
-        | Atom _
-        | Constant _
-        | Primitive _
-        | Name _ ->
-            (VarMultiset.empty, value)
+        | VAnnotate (v, _ty) ->
+            (* Evaluation_ir discards type annotations entirely *)
+            insert_reference_counting_val decls borrowed owned v
+        | Atom s -> (VarMultiset.empty, Evaluation_ir.Atom s)
+        | Constant c -> (VarMultiset.empty, Evaluation_ir.Constant c)
+        | Primitive p -> (VarMultiset.empty, Evaluation_ir.Primitive p)
+        | Name n -> (VarMultiset.empty, Evaluation_ir.Name n)
         | Inject (s, vs) ->
             let (dups, vs') = transform_val_sequence decls borrowed owned vs in 
-            let fvs = List.fold_left (fun acc v -> VarSet.union acc (get_fvs v)) VarSet.empty vs' in
-            (dups, WithIrMetadata.make ~fvs (Inject (s, vs')))
+            (dups, Evaluation_ir.Inject (s, vs'))
         | Variable (x, _) ->
             if VarSet.mem x owned || VarSet.mem x decl_vars then
               (* Owned or global declaration -- no dup needed *)
-              (VarMultiset.empty, value)
+              (VarMultiset.empty, Evaluation_ir.Variable x)
             else
-              (VarMultiset.singleton x, value)
+              (VarMultiset.singleton x, Evaluation_ir.Variable x)
         | Tuple vs -> 
             let (dups, vs') = transform_val_sequence decls borrowed owned vs in 
-            let fvs = List.fold_left (fun acc v -> VarSet.union acc (get_fvs v)) VarSet.empty vs' in
-            (dups, WithIrMetadata.make ~fvs (Tuple vs'))
-        | Lam { linear; parameters; result_type; body } ->
+            (dups, Evaluation_ir.Tuple vs')
+        | Lam { linear = _; parameters; result_type = _; body } ->
             let fvs = get_fvs value in
             let body_fvs = get_fvs body in
             let (used_vars, unused_vars) =
@@ -404,23 +323,13 @@ and insert_reference_counting_val decls borrowed owned value =
             (* to_drop: FVs not in owned environment *)
             let to_dup = VarSet.diff fvs owned |> VarSet.to_list |> VarMultiset.of_list in
             let to_drop = List.map (fun v -> (v, 1)) unused_vars in
-            let transformed_body =
-                let drop_node =
-                    WithIrMetadata.make ~fvs:(VarSet.of_list unused_vars)
-                        (Drop { vars = to_drop; names = [] })
-                in
-                let body_trans = insert_reference_counting_comp decls VarSet.empty body_owned_vars body in
-                let seq_fvs = VarSet.union (get_fvs drop_node) (get_fvs body_trans) in
-                if List.is_empty unused_vars then
-                    body_trans
-                else 
-                    WithIrMetadata.make ~fvs:seq_fvs (Seq (drop_node, body_trans))
-            in
-            (to_dup, WithIrMetadata.make ~fvs:(VarSet.union (VarSet.of_list used_vars) fvs) (Lam { linear; parameters; result_type; body = transformed_body }))
-and insert_reference_counting_guard decls borrowed guards_owned guard =
+            let body_trans = insert_reference_counting_comp decls VarSet.empty body_owned_vars body in
+            let transformed_body = insert_drop to_drop body_trans in
+            (to_dup, Evaluation_ir.Lam { parameters = List.map fst parameters; body = transformed_body })
+and insert_reference_counting_guard decls borrowed guards_owned guard : Evaluation_ir.guard =
     let irc borrowed owned c = insert_reference_counting_comp decls borrowed owned c in
     match WithIrMetadata.node guard with
-        | Receive { tag; payload_binders; mailbox_binder; strategy; cont } ->
+        | Receive { tag; payload_binders; mailbox_binder; strategy = _; cont } ->
             let binders_set =
                 mailbox_binder :: payload_binders
                 |> List.map Var.of_binder
@@ -434,19 +343,8 @@ and insert_reference_counting_guard decls borrowed guards_owned guard =
             (* to drop: all vars incl. binders minus what is actually used *)
             let cont_drop = VarSet.diff guards_owned_with_binders cont_owned in
             let translated_cont = irc borrowed cont_owned cont in
-            let final_cont =
-                if VarSet.is_empty cont_drop then
-                    translated_cont
-                else
-                    let drop_node =
-                        WithIrMetadata.make ~fvs:cont_drop
-                            (Drop { vars = (VarSet.elements cont_drop |> List.map (fun v -> (v, 1))); names = [] })
-                    in
-                    let seq_fvs = VarSet.union (get_fvs drop_node) (get_fvs translated_cont) in
-                    WithIrMetadata.make ~fvs:seq_fvs (Seq (drop_node, translated_cont))
-            in
-            let receive_fvs = get_fvs final_cont in
-            WithIrMetadata.make ~fvs:receive_fvs (Receive { tag; payload_binders; mailbox_binder; strategy; cont = final_cont })
+            let final_cont = mk_var_drop cont_drop translated_cont in
+            Evaluation_ir.Receive { tag; payload_binders; mailbox_binder; cont = final_cont }
         (* Similar to case-expressions, just processed in isolation *)
         | Empty (binder, e) ->
             let binder_var = Var.of_binder binder in
@@ -457,23 +355,12 @@ and insert_reference_counting_guard decls borrowed guards_owned guard =
             in
             let e_drop = VarSet.diff guards_owned_plus_binder e_owned in
             let translated_e = irc borrowed e_owned e in
-            let final_e =
-                if VarSet.is_empty e_drop then
-                    translated_e
-                else
-                    let drop_node =
-                        WithIrMetadata.make ~fvs:e_drop
-                            (Drop { vars = (VarSet.elements e_drop |> List.map (fun v -> (v, 1))); names = [] })
-                    in
-                    let seq_fvs = VarSet.union (get_fvs drop_node) (get_fvs translated_e) in
-                    WithIrMetadata.make ~fvs:seq_fvs (Seq (drop_node, translated_e))
-            in
-            let empty_fvs = get_fvs final_e in
-            WithIrMetadata.make ~fvs:empty_fvs (Empty (binder, final_e))
+            let final_e = mk_var_drop e_drop translated_e in
+            Evaluation_ir.Empty (binder, final_e)
         | Fail ->
-            WithIrMetadata.make ~fvs:VarSet.empty Fail
+            Evaluation_ir.Fail
 
-let insert_reference_counting prog =
+let insert_reference_counting prog : Evaluation_ir.program =
     let decls =
         prog.prog_decls
         |> List.map (fun (decl : Ir.decl) -> decl.decl_name)
@@ -484,9 +371,8 @@ let insert_reference_counting prog =
             Ir.VarSet.empty
             Ir.VarSet.empty
             c
-        |> Ir.normalise_seq
     in
-    let transform_decl (decl : Ir.decl) =
+    let transform_decl (decl : Ir.decl) : Evaluation_ir.decl =
         let parameter_vars =
             decl.decl_parameters
             |> List.map (fun (b, _) -> Ir.Var.of_binder b)
@@ -498,24 +384,15 @@ let insert_reference_counting prog =
         let body_owned_vars = used_params |> Ir.VarSet.of_list in
         let body_trans =
             insert_reference_counting_comp decls Ir.VarSet.empty body_owned_vars decl.decl_body
-            |> Ir.normalise_seq
         in
-        let decl_body =
-            if List.is_empty unused_params then
-                body_trans
-            else
-                let unused_set = unused_params |> Ir.VarSet.of_list in
-                let drop_node =
-                    WithIrMetadata.make ~fvs:unused_set
-                        (Drop { vars = (List.map (fun v -> (v, 1)) unused_params); names = [] })
-                in
-                let fvs = VarSet.union (get_fvs drop_node) (get_fvs body_trans) in
-                WithIrMetadata.make ~fvs (Seq (drop_node, body_trans))
-        in
-        { decl with decl_body }
+        let decl_body = insert_drop (List.map (fun v -> (v, 1)) unused_params) body_trans in
+        {
+            Evaluation_ir.decl_name = decl.decl_name;
+            decl_parameters = List.map fst decl.decl_parameters;
+            decl_body;
+        }
     in
     {
-        prog with
-            prog_decls = List.map transform_decl prog.prog_decls;
-            prog_body = Option.map transform_body prog.prog_body;
+        Evaluation_ir.prog_decls = List.map transform_decl prog.prog_decls;
+        prog_body = Option.map transform_body prog.prog_body;
     }

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -44,8 +44,7 @@ let rec let_bind_value (v : value) : (Binder.t * value) list * value =
             ([], WithIrMetadata.make ~fvs:(get_fvs v) (Lam { lambda with body = let_insert lambda.body }))
         | _ -> ([], v)
 
-(* Ensures [v] is a bare variable: first fixes up any nested Tuple/Inject content,
-   then binds the result itself if it isn't already a Variable. *)
+(* Takes a value and ensures that it's a variable, let-binding if required *)
 and force_variable (v : value) : (Binder.t * value) list * value =
     let (bindings, v') = let_bind_value v in
     match WithIrMetadata.node v' with
@@ -56,18 +55,12 @@ and force_variable (v : value) : (Binder.t * value) list * value =
                 WithIrMetadata.make ~fvs:(VarSet.singleton (Var.of_binder binder)) (Variable (Var.of_binder binder, None))
             in
             (bindings @ [ (binder, v') ], var_val)
-
 and force_variables (vs : value list) : (Binder.t * value) list * value list =
     List.fold_right
         (fun v (bindings, vars) ->
             let (v_bindings, var) = force_variable v in
             (v_bindings @ bindings, var :: vars))
         vs ([], [])
-
-(* Wraps [comp] in a let-binding per hoisted value. FVs are recomputed bottom-up:
-   a Let binds its binder, so the binder must *not* leak into the enclosing FV set.
-   Reference counting splits ownership using these sets, so an over-approximation
-   here makes it dup a variable that the continuation never uses (and then leak it). *)
 and insert_let_bindings (bindings : (Binder.t * value) list) (comp : comp) : comp =
     List.fold_right
         (fun (binder, term_value) cont ->
@@ -173,8 +166,6 @@ let unwrap_var = function
     | Variable (v, _) -> v
     | _ -> runtime_error "Tried to unwrap non-variable."
 
-(* Post let-insertion, positions typed as [Var.t] in Evaluation_ir (App args, message
-   payloads, Tuple/Inject fields) are guaranteed to hold bare variables. *)
 let unwrap_eval_var = function
     | Evaluation_ir.Variable v -> v
     | _ -> runtime_error "Tried to unwrap non-variable (evaluation IR)."
@@ -345,8 +336,7 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
                them itself. *)
             let body_fvs = get_fvs e in
             let transferred = VarSet.inter borrowed body_fvs in
-            (* Owned variables are moved into the body wholesale; the invariant on [owned]
-               guarantees they are all free in it. *)
+            (* Owned variables are moved into the body *)
             let body_owned = VarSet.union owned transferred in
             let body_borrowed = VarSet.diff borrowed transferred in
             let counted_body = irc body_borrowed body_owned e in
@@ -437,7 +427,8 @@ and insert_reference_counting_val decls borrowed owned value : VarMultiset.t * E
             (dups, Evaluation_ir.Inject (s, List.map unwrap_eval_var vs'))
         | Variable (x, _) ->
             if VarSet.mem x owned || VarSet.mem x decl_vars then
-              (* Owned or global declaration -- no dup needed *)
+              (* Don't bother adding dup instruction if variable is owned, or is
+              a declaration. *)
               (VarMultiset.empty, Evaluation_ir.Variable x)
             else
               (VarMultiset.singleton x, Evaluation_ir.Variable x)

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -251,6 +251,7 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
         | LetTuple { binders; tuple; cont } ->
             (* tuple is guaranteed a bare variable post let-insertion *)
             let tuple_var = unwrap_var (WithIrMetadata.node tuple) in
+            let owned = VarSet.diff owned (VarSet.singleton tuple_var) in
             let cont_fvs = get_fvs cont in
             let binders_set = 
                 binders
@@ -269,6 +270,7 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
             Evaluation_ir.LetTuple { binders = List.map fst binders; tuple = tuple_var; cont = final_translated_cont }
         | Case { term; branches; _ } ->
             let var = unwrap_var (WithIrMetadata.node term) in
+            let owned = VarSet.diff owned (VarSet.singleton var) in
             let mk_drop vars transformed_comp =
                 let var_list =
                     VarSet.elements vars

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -320,7 +320,7 @@ and insert_reference_counting_val decls borrowed owned value : VarMultiset.t * E
             let to_drop = List.map (fun v -> (v, 1)) unused_vars in
             let body_trans = insert_reference_counting_comp decls VarSet.empty body_owned_vars body in
             let transformed_body = insert_drop to_drop body_trans in
-            (to_dup, Evaluation_ir.Lam { parameters = List.map fst parameters; body = transformed_body })
+            (to_dup, Evaluation_ir.Lam { parameters = List.map fst parameters; fvs; body = transformed_body })
 and insert_reference_counting_guard decls borrowed guards_owned guard : Evaluation_ir.guard =
     let irc borrowed owned c = insert_reference_counting_comp decls borrowed owned c in
     match WithIrMetadata.node guard with
@@ -361,6 +361,7 @@ let insert_reference_counting prog : Evaluation_ir.program =
         |> List.map (fun (decl : Ir.decl) -> decl.decl_name)
     in
     let transform_body c =
+        let c = let_insert c in
         insert_reference_counting_comp
             decls
             Ir.VarSet.empty
@@ -368,17 +369,18 @@ let insert_reference_counting prog : Evaluation_ir.program =
             c
     in
     let transform_decl (decl : Ir.decl) : Evaluation_ir.decl =
+        let decl_body = let_insert decl.decl_body in
         let parameter_vars =
             decl.decl_parameters
             |> List.map (fun (b, _) -> Ir.Var.of_binder b)
         in
-        let body_fvs = get_fvs decl.decl_body in
+        let body_fvs = get_fvs decl_body in
         let (used_params, unused_params) =
             List.partition (fun v -> VarSet.mem v body_fvs) parameter_vars
         in
         let body_owned_vars = used_params |> Ir.VarSet.of_list in
         let body_trans =
-            insert_reference_counting_comp decls Ir.VarSet.empty body_owned_vars decl.decl_body
+            insert_reference_counting_comp decls Ir.VarSet.empty body_owned_vars decl_body
         in
         let decl_body = insert_drop (List.map (fun v -> (v, 1)) unused_params) body_trans in
         {

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -128,8 +128,8 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
               intersection of the current owned environment and the free variables of the subexpression.
               Then in the body, drop everything that is in the owned environment but not the current environment.
               Borrowed environment is just the current borrowed environment. *)
-        (* The 'match' schema in the Perceus paper rather unhelpfully has a variable literal as the scrutinee.
-           However this isn't too big a deal -- drops will ensure same FVs in each branch. Then we can just
+        (* The 'match' schema in the Perceus paper has a variable literal as the scrutinee.
+           'If' is a specialisation of that rule. Drops will ensure same FVs in each branch. Then we can just
             say that the borrowed environment for the test is the union of the borrowed env and the owned env of the branches. *)
         | If { test; then_expr; else_expr } ->
             let branches_owned = VarSet.inter owned
@@ -241,11 +241,6 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
             let translated_guards = List.map (ircg borrowed guards_owned) guards in
             insert_dup dups
                 (Evaluation_ir.Guard { target = translated_target; pattern; guards = translated_guards; iname = Option.get iname })
-        | Drop _
-        | Dup _ -> raise <| 
-            Errors.internal_error
-                "reference_counting.ml"
-                "Reference counting pass should not see Drop or Dup nodes"
 (* Helper function to annotate an ordered sequence of values. We need to consider all subsequent
     variables used in a sequence as borrowed. The best way of doing this is to reverse the
     list of variables and keep the borrow set as an accumulator, then reverse again at the end. *)

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -13,50 +13,137 @@ let pp_varset ppf s =
 
 
 (* Let-insertion: ensures the subject of a Case, LetTuple, or function
-   application is always a bare variable, hoisting it into a fresh
-   let-binding otherwise. Required before reference counting / evaluation
-   in order to better support Perceus heap semantics. Also simplifies the pass. *)
-let bind_subject (comp : comp) (subject : value) (rest_fvs : varset) (rebuild : value -> comp_node) : comp =
-    match WithIrMetadata.node subject with
-        | Variable _ -> comp
+   application is always a bare variable, and that every argument of a
+   Tuple/Inject construction is a bare variable, hoisting non-variable
+   values into fresh let-bindings otherwise. Required before reference
+   counting / evaluation in order to better support Perceus heap semantics.
+
+   Since we can't insert a let-binder directly into a value, value-level
+   helpers below just return the auxiliary (binder, bound value) pairs
+   they need alongside the rewritten value/value list like we do with dups. *)
+let rec let_bind_value (v : value) : (Binder.t * value) list * value =
+    let get_new_fvs bindings =
+        VarSet.union
+            (get_fvs v)
+            (List.map (Var.of_binder << fst) bindings |> VarSet.of_list)
+    in
+    match WithIrMetadata.node v with
+        | VAnnotate (inner, ty) ->
+            let (bindings, inner') = let_bind_value inner in
+            let new_fvs = get_new_fvs bindings in
+            (bindings, WithIrMetadata.make ~fvs:new_fvs (VAnnotate (inner', ty)))
+        | Tuple vs ->
+            let (bindings, vars) = force_variables vs in
+            let new_fvs = get_new_fvs bindings in
+            (bindings, WithIrMetadata.make ~fvs:new_fvs (Tuple vars))
+        | Inject (s, vs) ->
+            let (bindings, vars) = force_variables vs in
+            let new_fvs = get_new_fvs bindings in
+            (bindings, WithIrMetadata.make ~fvs:new_fvs (Inject (s, vars)))
+        | Lam lambda ->
+            ([], WithIrMetadata.make ~fvs:(get_fvs v) (Lam { lambda with body = let_insert lambda.body }))
+        | _ -> ([], v)
+
+(* Ensures [v] is a bare variable: first fixes up any nested Tuple/Inject content,
+   then binds the result itself if it isn't already a Variable. *)
+and force_variable (v : value) : (Binder.t * value) list * value =
+    let (bindings, v') = let_bind_value v in
+    match WithIrMetadata.node v' with
+        | Variable _ -> (bindings, v')
         | _ ->
             let binder = Binder.make () in
-            let var = Var.of_binder binder in
-            let var_val = WithIrMetadata.make ~fvs:(VarSet.singleton var) (Variable (var, None)) in
-            let term = WithIrMetadata.make ~fvs:(get_fvs subject) (Return subject) in
-            let cont = WithIrMetadata.make ~fvs:(VarSet.add var rest_fvs) (rebuild var_val) in
-            { comp with node = Let { binder; term; cont } }
+            let var_val =
+                WithIrMetadata.make ~fvs:(VarSet.singleton (Var.of_binder binder)) (Variable (Var.of_binder binder, None))
+            in
+            (bindings @ [ (binder, v') ], var_val)
 
-let let_insert : comp -> comp =
-    let visitor =
-        object
-            inherit [_] Ir.map as super
+and force_variables (vs : value list) : (Binder.t * value) list * value list =
+    List.fold_right
+        (fun v (bindings, vars) ->
+            let (v_bindings, var) = force_variable v in
+            (v_bindings @ bindings, var :: vars))
+        vs ([], [])
 
-            method! visit_comp env comp =
-                let comp = super#visit_comp env comp in
-                match WithIrMetadata.node comp with
-                    | App { func; args } ->
-                        let rest_fvs = List.fold_left (fun acc a -> VarSet.union acc (get_fvs a)) VarSet.empty args in
-                        bind_subject comp func rest_fvs (fun func -> App { func; args })
-                    | LetTuple { binders; tuple; cont } ->
-                        let bnd_vars = binders |> List.map (fun (b, _) -> Var.of_binder b) |> VarSet.of_list in
-                        let rest_fvs = VarSet.diff (get_fvs cont) bnd_vars in
-                        bind_subject comp tuple rest_fvs (fun tuple -> LetTuple { binders; tuple; cont })
-                    | Case { term; ty; branches } ->
-                        let rest_fvs =
-                            branches
-                            |> List.map (fun (params, body, _) ->
-                                let bound_vars = List.map Var.of_binder params |> VarSet.of_list in
-                                VarSet.diff (get_fvs body) bound_vars)
-                            |> VarSet.union_many
-                        in
-                        bind_subject comp term rest_fvs (fun term -> Case { term; ty; branches })
-                    | _ -> comp
+(* Like force_variables, but doesn't force each element to itself be a variable -
+   only fixes up any nested Tuple/Inject content (e.g. for App's args). *)
+and let_bind_value_list (vs : value list) : (Binder.t * value) list * value list =
+    List.fold_right
+        (fun v (bindings, vs') ->
+            let (v_bindings, v') = let_bind_value v in
+            (v_bindings @ bindings, v' :: vs'))
+        vs ([], [])
 
-            method visit_t _env x = x
-        end
-    in
-    visitor#visit_comp ()
+and insert_let_bindings (fvs : varset) (bindings : (Binder.t * value) list) (comp : comp) : comp =
+    List.fold_right
+        (fun (binder, term_value) cont ->
+            let term = WithIrMetadata.make ~fvs:(get_fvs term_value) (Return term_value) in
+            WithIrMetadata.make ~fvs (Let { binder; term; cont }))
+        bindings comp
+
+and fvs_with_bindings (comp : comp) (bindings : (Binder.t * value) list) : varset =
+    VarSet.union
+        (get_fvs comp)
+        (List.map (Var.of_binder << fst) bindings |> VarSet.of_list)
+
+and let_insert (comp : comp) : comp =
+    match WithIrMetadata.node comp with
+        | Annotate (c, ty) ->
+            WithIrMetadata.make ~fvs:(get_fvs comp) (Annotate (let_insert c, ty))
+        | Let { binder; term; cont } ->
+            WithIrMetadata.make ~fvs:(get_fvs comp) (Let { binder; term = let_insert term; cont = let_insert cont })
+        | Seq (e1, e2) ->
+            WithIrMetadata.make ~fvs:(get_fvs comp) (Seq (let_insert e1, let_insert e2))
+        | Return v ->
+            let (bindings, v') = let_bind_value v in
+            let fvs = fvs_with_bindings comp bindings in
+            insert_let_bindings fvs bindings (WithIrMetadata.make ~fvs (Return v'))
+        | App { func; args } ->
+            let (func_bindings, func') = force_variable func in
+            let (args_bindings, args') = let_bind_value_list args in
+            let bindings = func_bindings @ args_bindings in
+            let fvs = fvs_with_bindings comp bindings in
+            insert_let_bindings fvs bindings (WithIrMetadata.make ~fvs (App { func = func'; args = args' }))
+        | If { test; then_expr; else_expr } ->
+            let (bindings, test') = let_bind_value test in
+            let fvs = fvs_with_bindings comp bindings in
+            insert_let_bindings fvs bindings
+                (WithIrMetadata.make ~fvs (If { test = test'; then_expr = let_insert then_expr; else_expr = let_insert else_expr }))
+        | LetTuple { binders; tuple; cont } ->
+            let (bindings, tuple') = force_variable tuple in
+            let fvs = fvs_with_bindings comp bindings in
+            insert_let_bindings fvs bindings
+                (WithIrMetadata.make ~fvs (LetTuple { binders; tuple = tuple'; cont = let_insert cont }))
+        | Case { term; ty; branches } ->
+            let (bindings, term') = force_variable term in
+            let branches' = List.map (fun (bnds, body, name) -> (bnds, let_insert body, name)) branches in
+            let fvs = fvs_with_bindings comp bindings in
+            insert_let_bindings fvs bindings (WithIrMetadata.make ~fvs (Case { term = term'; ty; branches = branches' }))
+        | New _ -> comp
+        | Spawn body ->
+            WithIrMetadata.make ~fvs:(get_fvs comp) (Spawn (let_insert body))
+        | Send { target; message = (tag, vals); iname } ->
+            let (target_bindings, target') = let_bind_value target in
+            let (val_bindings, vals') = let_bind_value_list vals in
+            let bindings = target_bindings @ val_bindings in
+            let fvs = fvs_with_bindings comp bindings in
+            insert_let_bindings fvs bindings
+                (WithIrMetadata.make ~fvs (Send { target = target'; message = (tag, vals'); iname }))
+        | Free (v, iname) ->
+            let (bindings, v') = let_bind_value v in
+            let fvs = fvs_with_bindings comp bindings in
+            insert_let_bindings fvs bindings (WithIrMetadata.make ~fvs (Free (v', iname)))
+        | Guard { target; pattern; guards; iname } ->
+            let (bindings, target') = let_bind_value target in
+            let guards' = List.map let_insert_guard guards in
+            let fvs = fvs_with_bindings comp bindings in
+            insert_let_bindings fvs bindings
+                (WithIrMetadata.make ~fvs (Guard { target = target'; pattern; guards = guards'; iname }))
+
+and let_insert_guard (guard : guard) : guard =
+    match WithIrMetadata.node guard with
+        | Receive r -> WithIrMetadata.make ~fvs:(get_fvs guard) (Receive { r with cont = let_insert r.cont })
+        | Empty (b, c) -> WithIrMetadata.make ~fvs:(get_fvs guard) (Empty (b, let_insert c))
+        | Fail -> guard
 
 let unwrap_var = function
     | Variable (v, _) -> v
@@ -293,8 +380,9 @@ and insert_reference_counting_val decls borrowed owned value : VarMultiset.t * E
         | Primitive p -> (VarMultiset.empty, Evaluation_ir.Primitive p)
         | Name n -> (VarMultiset.empty, Evaluation_ir.Name n)
         | Inject (s, vs) ->
-            let (dups, vs') = transform_val_sequence decls borrowed owned vs in 
-            (dups, Evaluation_ir.Inject (s, vs'))
+            (* vs are guaranteed bare variables post let-insertion *)
+            let vars = List.map (fun v -> unwrap_var (WithIrMetadata.node v)) vs in
+            (VarMultiset.empty, Evaluation_ir.Inject (s, vars))
         | Variable (x, _) ->
             if VarSet.mem x owned || VarSet.mem x decl_vars then
               (* Owned or global declaration -- no dup needed *)
@@ -302,8 +390,9 @@ and insert_reference_counting_val decls borrowed owned value : VarMultiset.t * E
             else
               (VarMultiset.singleton x, Evaluation_ir.Variable x)
         | Tuple vs -> 
-            let (dups, vs') = transform_val_sequence decls borrowed owned vs in 
-            (dups, Evaluation_ir.Tuple vs')
+            (* vs are guaranteed bare variables post let-insertion *)
+            let vars = List.map (fun v -> unwrap_var (WithIrMetadata.node v)) vs in
+            (VarMultiset.empty, Evaluation_ir.Tuple vars)
         | Lam { linear = _; parameters; result_type = _; body } ->
             let fvs = get_fvs value in
             let body_fvs = get_fvs body in

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -64,26 +64,28 @@ and force_variables (vs : value list) : (Binder.t * value) list * value list =
             (v_bindings @ bindings, var :: vars))
         vs ([], [])
 
-(* Like force_variables, but doesn't force each element to itself be a variable -
-   only fixes up any nested Tuple/Inject content (e.g. for App's args). *)
-and let_bind_value_list (vs : value list) : (Binder.t * value) list * value list =
-    List.fold_right
-        (fun v (bindings, vs') ->
-            let (v_bindings, v') = let_bind_value v in
-            (v_bindings @ bindings, v' :: vs'))
-        vs ([], [])
-
-and insert_let_bindings (fvs : varset) (bindings : (Binder.t * value) list) (comp : comp) : comp =
+(* Wraps [comp] in a let-binding per hoisted value. FVs are recomputed bottom-up:
+   a Let binds its binder, so the binder must *not* leak into the enclosing FV set.
+   Reference counting splits ownership using these sets, so an over-approximation
+   here makes it dup a variable that the continuation never uses (and then leak it). *)
+and insert_let_bindings (bindings : (Binder.t * value) list) (comp : comp) : comp =
     List.fold_right
         (fun (binder, term_value) cont ->
             let term = WithIrMetadata.make ~fvs:(get_fvs term_value) (Return term_value) in
+            let fvs =
+                VarSet.union
+                    (get_fvs term_value)
+                    (VarSet.remove (Var.of_binder binder) (get_fvs cont))
+            in
             WithIrMetadata.make ~fvs (Let { binder; term; cont }))
         bindings comp
 
-and fvs_with_bindings (comp : comp) (bindings : (Binder.t * value) list) : varset =
-    VarSet.union
-        (get_fvs comp)
-        (List.map (Var.of_binder << fst) bindings |> VarSet.of_list)
+(* Union of the FVs of a list of FV-annotated nodes (values, comps, or guards). *)
+and union_fvs : 'a. 'a WithIrMetadata.t list -> varset = fun nodes ->
+    List.fold_left (fun acc n -> VarSet.union acc (get_fvs n)) VarSet.empty nodes
+
+and bound_fvs (bound : Var.t list) (body : comp) : varset =
+    VarSet.diff (get_fvs body) (VarSet.of_list bound)
 
 and let_insert (comp : comp) : comp =
     match WithIrMetadata.node comp with
@@ -95,8 +97,8 @@ and let_insert (comp : comp) : comp =
             WithIrMetadata.make ~fvs:(get_fvs comp) (Seq (let_insert e1, let_insert e2))
         | Return v ->
             let (bindings, v') = let_bind_value v in
-            let fvs = fvs_with_bindings comp bindings in
-            insert_let_bindings fvs bindings (WithIrMetadata.make ~fvs (Return v'))
+            insert_let_bindings bindings
+                (WithIrMetadata.make ~fvs:(get_fvs v') (Return v'))
         | App { func; args } ->
             let (func_bindings, func') =
                 begin
@@ -105,44 +107,57 @@ and let_insert (comp : comp) : comp =
                     | _ -> force_variable func
                 end
             in
-            let (args_bindings, args') = let_bind_value_list args in
+            let (args_bindings, args') = force_variables args in
             let bindings = func_bindings @ args_bindings in
-            let fvs = fvs_with_bindings comp bindings in
-            insert_let_bindings fvs bindings (WithIrMetadata.make ~fvs (App { func = func'; args = args' }))
+            let fvs = union_fvs (func' :: args') in
+            insert_let_bindings bindings (WithIrMetadata.make ~fvs (App { func = func'; args = args' }))
         | If { test; then_expr; else_expr } ->
             let (bindings, test') = let_bind_value test in
-            let fvs = fvs_with_bindings comp bindings in
-            insert_let_bindings fvs bindings
-                (WithIrMetadata.make ~fvs (If { test = test'; then_expr = let_insert then_expr; else_expr = let_insert else_expr }))
+            let then_expr = let_insert then_expr in
+            let else_expr = let_insert else_expr in
+            let fvs =
+                VarSet.union (get_fvs test') (union_fvs [ then_expr; else_expr ])
+            in
+            insert_let_bindings bindings
+                (WithIrMetadata.make ~fvs (If { test = test'; then_expr; else_expr }))
         | LetTuple { binders; tuple; cont } ->
             let (bindings, tuple') = force_variable tuple in
-            let fvs = fvs_with_bindings comp bindings in
-            insert_let_bindings fvs bindings
-                (WithIrMetadata.make ~fvs (LetTuple { binders; tuple = tuple'; cont = let_insert cont }))
+            let cont = let_insert cont in
+            let bound = List.map (Var.of_binder << fst) binders in
+            let fvs = VarSet.union (get_fvs tuple') (bound_fvs bound cont) in
+            insert_let_bindings bindings
+                (WithIrMetadata.make ~fvs (LetTuple { binders; tuple = tuple'; cont }))
         | Case { term; ty; branches } ->
             let (bindings, term') = force_variable term in
             let branches' = List.map (fun (bnds, body, name) -> (bnds, let_insert body, name)) branches in
-            let fvs = fvs_with_bindings comp bindings in
-            insert_let_bindings fvs bindings (WithIrMetadata.make ~fvs (Case { term = term'; ty; branches = branches' }))
+            let fvs =
+                List.fold_left
+                    (fun acc (bnds, body, _) ->
+                        VarSet.union acc (bound_fvs (List.map Var.of_binder bnds) body))
+                    (get_fvs term')
+                    branches'
+            in
+            insert_let_bindings bindings (WithIrMetadata.make ~fvs (Case { term = term'; ty; branches = branches' }))
         | New _ -> comp
         | Spawn body ->
-            WithIrMetadata.make ~fvs:(get_fvs comp) (Spawn (let_insert body))
+            let body = let_insert body in
+            WithIrMetadata.make ~fvs:(get_fvs body) (Spawn body)
         | Send { target; message = (tag, vals); iname } ->
             let (target_bindings, target') = let_bind_value target in
-            let (val_bindings, vals') = let_bind_value_list vals in
+            let (val_bindings, vals') = force_variables vals in
             let bindings = target_bindings @ val_bindings in
-            let fvs = fvs_with_bindings comp bindings in
-            insert_let_bindings fvs bindings
+            let fvs = union_fvs (target' :: vals') in
+            insert_let_bindings bindings
                 (WithIrMetadata.make ~fvs (Send { target = target'; message = (tag, vals'); iname }))
         | Free (v, iname) ->
             let (bindings, v') = let_bind_value v in
-            let fvs = fvs_with_bindings comp bindings in
-            insert_let_bindings fvs bindings (WithIrMetadata.make ~fvs (Free (v', iname)))
+            insert_let_bindings bindings
+                (WithIrMetadata.make ~fvs:(get_fvs v') (Free (v', iname)))
         | Guard { target; pattern; guards; iname } ->
             let (bindings, target') = let_bind_value target in
             let guards' = List.map let_insert_guard guards in
-            let fvs = fvs_with_bindings comp bindings in
-            insert_let_bindings fvs bindings
+            let fvs = VarSet.union (get_fvs target') (union_fvs guards') in
+            insert_let_bindings bindings
                 (WithIrMetadata.make ~fvs (Guard { target = target'; pattern; guards = guards'; iname }))
 
 and let_insert_guard (guard : guard) : guard =
@@ -157,6 +172,12 @@ let runtime_error err =
 let unwrap_var = function
     | Variable (v, _) -> v
     | _ -> runtime_error "Tried to unwrap non-variable."
+
+(* Post let-insertion, positions typed as [Var.t] in Evaluation_ir (App args, message
+   payloads, Tuple/Inject fields) are guaranteed to hold bare variables. *)
+let unwrap_eval_var = function
+    | Evaluation_ir.Variable v -> v
+    | _ -> runtime_error "Tried to unwrap non-variable (evaluation IR)."
 
 let insert_dup (dups : (Var.t * int) list) (comp : Evaluation_ir.comp) : Evaluation_ir.comp =
     let open Evaluation_ir in
@@ -228,7 +249,8 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
                                 Ir.pp_value func)
             in 
             let (dups, args') = transform_val_sequence decls borrowed owned args in
-            insert_dup (VarMultiset.bindings dups) (Evaluation_ir.App { func = func_target; args = args' })
+            let arg_vars = List.map unwrap_eval_var args' in
+            insert_dup (VarMultiset.bindings dups) (Evaluation_ir.App { func = func_target; args = arg_vars })
         (* When doing branching control flow: when processing each subexpression, owned environment is the
               intersection of the current owned environment and the free variables of the subexpression.
               Then in the body, drop everything that is in the owned environment but not the current environment.
@@ -334,8 +356,11 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
             begin
                 match transform_val_sequence decls borrowed owned (target :: message_values) with
                     | (dups, target' :: message_values') ->
+                        (* Payloads are stored in the mailbox and rebound at the receive, so
+                           each must be a bare variable; the target stays a general value. *)
+                        let message_vars = List.map unwrap_eval_var message_values' in
                         insert_dup (VarMultiset.bindings dups)
-                            (Evaluation_ir.Send { target = target'; message = (tag, message_values'); iname = Option.get iname })
+                            (Evaluation_ir.Send { target = target'; message = (tag, message_vars); iname = Option.get iname })
                     (* impossible; transform_val_sequence always gives the same number of values back *)
                     | _ -> runtime_error "Mismatch in sequence length (transform_val_sequence)"
             end
@@ -408,19 +433,17 @@ and insert_reference_counting_val decls borrowed owned value : VarMultiset.t * E
         | Primitive p -> (VarMultiset.empty, Evaluation_ir.Primitive p)
         | Name n -> (VarMultiset.empty, Evaluation_ir.Name n)
         | Inject (s, vs) ->
-            (* vs are guaranteed bare variables post let-insertion *)
-            let vars = List.map (fun v -> unwrap_var (WithIrMetadata.node v)) vs in
-            (VarMultiset.empty, Evaluation_ir.Inject (s, vars))
+            let (dups, vs') = transform_val_sequence decls borrowed owned vs in
+            (dups, Evaluation_ir.Inject (s, List.map unwrap_eval_var vs'))
         | Variable (x, _) ->
             if VarSet.mem x owned || VarSet.mem x decl_vars then
               (* Owned or global declaration -- no dup needed *)
               (VarMultiset.empty, Evaluation_ir.Variable x)
             else
               (VarMultiset.singleton x, Evaluation_ir.Variable x)
-        | Tuple vs -> 
-            (* vs are guaranteed bare variables post let-insertion *)
-            let vars = List.map (fun v -> unwrap_var (WithIrMetadata.node v)) vs in
-            (VarMultiset.empty, Evaluation_ir.Tuple vars)
+        | Tuple vs ->
+            let (dups, vs') = transform_val_sequence decls borrowed owned vs in
+            (dups, Evaluation_ir.Tuple (List.map unwrap_eval_var vs'))
         | Lam { linear = _; parameters; result_type = _; body } ->
             let fvs = get_fvs value in
             let body_fvs = get_fvs body in

--- a/lib/interp/reference_counting.ml
+++ b/lib/interp/reference_counting.ml
@@ -151,9 +151,12 @@ and let_insert_guard (guard : guard) : guard =
         | Empty (b, c) -> WithIrMetadata.make ~fvs:(get_fvs guard) (Empty (b, let_insert c))
         | Fail -> guard
 
+let runtime_error err =
+    raise <| Errors.internal_error "reference_counting.ml" err
+
 let unwrap_var = function
     | Variable (v, _) -> v
-    | _ -> raise <| Errors.internal_error "reference_counting.ml" "Tried to unwrap non-variable."
+    | _ -> runtime_error "Tried to unwrap non-variable."
 
 let insert_dup (dups : (Var.t * int) list) (comp : Evaluation_ir.comp) : Evaluation_ir.comp =
     let open Evaluation_ir in
@@ -218,7 +221,11 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
                 match WithIrMetadata.node func with
                     | Variable (v, _) -> Evaluation_ir.UserFunction v
                     | Primitive p -> Evaluation_ir.PrimitiveFunction p
-                    | _ -> assert false (* FIXME: more informative error*)
+                    | _ ->
+                        runtime_error
+                            (Format.asprintf
+                                "Application target should be a variable or primitive; got %a"
+                                Ir.pp_value func)
             in 
             let (dups, args') = transform_val_sequence decls borrowed owned args in
             insert_dup (VarMultiset.bindings dups) (Evaluation_ir.App { func = func_target; args = args' })
@@ -330,7 +337,7 @@ let rec insert_reference_counting_comp decls borrowed owned comp : Evaluation_ir
                         insert_dup (VarMultiset.bindings dups)
                             (Evaluation_ir.Send { target = target'; message = (tag, message_values'); iname = Option.get iname })
                     (* impossible; transform_val_sequence always gives the same number of values back *)
-                    | _ -> assert false
+                    | _ -> runtime_error "Mismatch in sequence length (transform_val_sequence)"
             end
         | Free (v, iname) ->
             let (dups, v') = ircv borrowed owned v in

--- a/lib/interp/runtime.ml
+++ b/lib/interp/runtime.ml
@@ -1,7 +1,7 @@
 open Common
 open Runtime_common
 open Eio
-open Ir
+open Evaluation_ir
 
 (* A mailbox is represented internally as a pair of a reference count, and a
 list of runtime messages. *)
@@ -110,8 +110,7 @@ and update_value_refcount runtime name count sign =
         match value with
         | RuntimeValue.Closure { lambda; value_env } ->
           let fv_runtime_names =
-            lambda.body
-            |> WithIrMetadata.fvs
+            lambda.fvs
             |> VarSet.elements
             |> List.filter_map (fun fv ->
                 match VarMap.find_opt fv value_env with
@@ -236,26 +235,11 @@ let drop (runtime : t) (counts : (RuntimeName.t * int) list) : unit =
   let to_wake = apply_refcount_delta runtime counts (-1) in
   wake_blocked_many runtime to_wake
 
-let lookup_lambda runtime name =
+let lookup_tracked_value (runtime : t) (name : RuntimeName.t) : RuntimeValue.t =
   match Hashtbl.find_opt runtime.reference_counted_values name with
-    | Some (_, runtime_value) ->
-      begin
-        match runtime_value with
-          | RuntimeValue.Closure { lambda; value_env } ->
-              let fvs =
-                value_env
-                |> VarMap.bindings
-                |> List.map fst
-                |> VarSet.of_list
-              in
-              (lambda, fvs, value_env)
-          | bad ->
-              runtime_error 
-                (Format.asprintf "Looking up lambda in RC map: name %a maps to non-lambda %a"
-                  RuntimeName.pp name Ir.pp_value (RuntimeValue.to_ir bad))
-      end
+    | Some (_, runtime_value) -> runtime_value
     | None -> runtime_error
-      (Format.asprintf "Looking up lambda in RC map: name %a unbound" RuntimeName.pp name)
+      (Format.asprintf "Looking up tracked value in RC map: name %a unbound" RuntimeName.pp name)
 
 let record_value runtime rt_val =
   let new_ref = RuntimeName.make_value () in

--- a/lib/interp/runtime.ml
+++ b/lib/interp/runtime.ml
@@ -119,6 +119,15 @@ and update_value_refcount runtime name count sign =
           in
           let to_wake = apply_refcount_delta runtime fv_runtime_names (-1) in
           wake_blocked_many runtime to_wake
+        | RuntimeValue.Tuple ts | RuntimeValue.Inject (_, ts) ->
+          let contained_names =
+            List.filter_map (function
+              | RuntimeValue.Name runtime_name -> Some (runtime_name, 1)
+              | _ -> None)
+              ts
+          in
+          let to_wake = apply_refcount_delta runtime contained_names (-1) in
+          wake_blocked_many runtime to_wake
         | _ -> ()
       end
     else

--- a/lib/interp/runtime.ml
+++ b/lib/interp/runtime.ml
@@ -195,10 +195,12 @@ let send (runtime : t) (runtime_name : RuntimeName.t) (message : Runtime_common.
       (Format.asprintf "Send target mailbox %a does not exist" RuntimeName.pp runtime_name)
   | Some (refcount, messages) ->
     let next_refcount = refcount - 1 in
-    if next_refcount < 1 then
-      runtime_error
-        (Format.asprintf "Mailbox %a reference count became < 1 after send: %a"
-          RuntimeName.pp runtime_name pp_mailbox_entry (refcount, messages));
+    let () =
+      if next_refcount < 1 then
+        runtime_error
+          (Format.asprintf "Mailbox %a reference count became < 1 after send: %a"
+            RuntimeName.pp runtime_name pp_mailbox_entry (refcount, messages))
+    in
     Hashtbl.replace runtime.mailboxes runtime_name (next_refcount, messages @ [message]);
     begin
       match Hashtbl.find_opt runtime.blocked runtime_name with

--- a/lib/interp/runtime.ml
+++ b/lib/interp/runtime.ml
@@ -112,19 +112,18 @@ and update_value_refcount runtime name count sign =
           let fv_runtime_names =
             lambda.fvs
             |> VarSet.elements
-            |> List.filter_map (fun fv ->
+            |> List.concat_map (fun fv ->
                 match VarMap.find_opt fv value_env with
-                | Some (RuntimeValue.Name runtime_name) -> Some (runtime_name, 1)
-                | _ -> None)
+                | Some v -> runtime_names_in_runtime_value v
+                | None -> [])
+            |> count_names
           in
           let to_wake = apply_refcount_delta runtime fv_runtime_names (-1) in
           wake_blocked_many runtime to_wake
         | RuntimeValue.Tuple ts | RuntimeValue.Inject (_, ts) ->
           let contained_names =
-            List.filter_map (function
-              | RuntimeValue.Name runtime_name -> Some (runtime_name, 1)
-              | _ -> None)
-              ts
+            List.concat_map runtime_names_in_runtime_value ts
+            |> count_names
           in
           let to_wake = apply_refcount_delta runtime contained_names (-1) in
           wake_blocked_many runtime to_wake

--- a/lib/interp/runtime.mli
+++ b/lib/interp/runtime.mli
@@ -1,5 +1,4 @@
 (* Interface for the runtime system. *)
-open Common
 open Runtime_common
 
 type t
@@ -16,31 +15,31 @@ type await_result =
    We require the callback in order to avoid a circular depdenency
    between the runtime and the evaluator.
 *)
-val run : Ir.program -> (t -> unit) -> unit
+val run : Evaluation_ir.program -> (t -> unit) -> unit
 (* Spawns a new thread on the given runtime.
    The thunk should evaluate the body of the spawned process. *)
 val spawn : t -> (unit -> unit) -> unit
 (* Creates a fresh mailbox and returns its new runtime name. *)
-val new_mailbox : t -> Ir.RuntimeName.t
+val new_mailbox : t -> Evaluation_ir.RuntimeName.t
 (* Frees the mailbox with the given runtime name. Raises an error if the
    reference count of the mailbox is not exactly 1. *)
-val free_mailbox : t -> Ir.RuntimeName.t -> unit
+val free_mailbox : t -> Evaluation_ir.RuntimeName.t -> unit
 (* Blocks awaiting a message. Returns an await_result. *)
-val await_message : t -> Ir.RuntimeName.t -> Ir.message_tag list -> await_result
+val await_message : t -> Evaluation_ir.RuntimeName.t -> Evaluation_ir.message_tag list -> await_result
 (* Sends a message to the given mailbox. *)
-val send :  t -> Ir.RuntimeName.t -> Runtime_common.runtime_message  -> unit
+val send :  t -> Evaluation_ir.RuntimeName.t -> Runtime_common.runtime_message  -> unit
 (* Sleeps the current thread for the given number of milliseconds. Will yield. *)
 val sleep : t -> int -> unit
 (* Called after each computation step. May potentially yield to another thread. *)
 val yield : t -> (unit -> unit) -> unit
 (* Given a list [(a, n)], increments the reference count of each a_i by n_i *)
-val dup : t -> (Ir.RuntimeName.t * int) list -> unit
+val dup : t -> (Evaluation_ir.RuntimeName.t * int) list -> unit
 (* Given a list [(a, n)], decrements the reference count of each a_i by n_i *)
-val drop : t -> (Ir.RuntimeName.t * int) list -> unit
+val drop : t -> (Evaluation_ir.RuntimeName.t * int) list -> unit
 
-(* Looks up the definition, free variable set, and stored environment of a closure. *)
-val lookup_lambda : t -> Ir.RuntimeName.t -> (Ir.lambda * Ir.VarSet.t * value_env)
+(* Looks up the tracked runtime value for a given reference-counted name. *)
+val lookup_tracked_value : t -> Evaluation_ir.RuntimeName.t -> RuntimeValue.t
 (* Records a value for reference counting, returning a runtime name *)
-val record_value : t -> RuntimeValue.t -> Ir.RuntimeName.t
+val record_value : t -> RuntimeValue.t -> Evaluation_ir.RuntimeName.t
 (* Called when a thread has finished evaluating. *)
 val finish_thread : t -> unit

--- a/lib/interp/runtime_common.ml
+++ b/lib/interp/runtime_common.ml
@@ -3,7 +3,13 @@ open Common_types
 open Evaluation_ir
 
 module VarMap = Map.Make(Var)
-module RuntimeMap = Map.Make(RuntimeName)
+module RuntimeNameMap = Map.Make(RuntimeName)
+
+let count_names names =
+  List.fold_left
+    (fun acc n -> RuntimeNameMap.update n (function Some c -> Some (c + 1) | None -> Some 1) acc)
+    RuntimeNameMap.empty names
+  |> RuntimeNameMap.bindings
 
 let runtime_error message =
   raise (Errors.internal_error "eval.ml" message)
@@ -62,6 +68,16 @@ end
 type value_env = RuntimeValue.value_env
 
 type runtime_message = (message_tag * RuntimeValue.t list)
+
+(* All runtime names reachable from a value, descending through any nesting of
+   Tuple/Inject (e.g. a mailbox stored inside a variant stored inside a tuple). *)
+let rec runtime_names_in_runtime_value value =
+  let open RuntimeValue in
+  match value with
+  | Name runtime_name -> [runtime_name]
+  | Tuple vs
+  | Inject (_, vs) -> List.concat_map runtime_names_in_runtime_value vs
+  | Atom _ | Constant _ | Primitive _ | Closure _ | Declaration _ -> []
 
 let should_ref_count =
   let open RuntimeValue in

--- a/lib/interp/runtime_common.ml
+++ b/lib/interp/runtime_common.ml
@@ -1,5 +1,5 @@
 open Common
-open Ir
+open Evaluation_ir
 
 module VarMap = Map.Make(Var)
 module RuntimeMap = Map.Make(RuntimeName)
@@ -28,17 +28,16 @@ module RuntimeValue = struct
     | Declaration of Var.t
 
   let rec of_ir value_env value =
-    match WithIrMetadata.node value with
-    | Ir.VAnnotate (v, _) -> of_ir value_env v
-    | Ir.Atom a -> Atom a
-    | Ir.Constant c -> Constant c
-    | Ir.Primitive p -> Primitive p
-    | Ir.Name n -> Name n
-    | Ir.Tuple vs -> Tuple (List.map (of_ir value_env) vs)
-    | Ir.Inject (s, vs) -> Inject (s, List.map (of_ir value_env) vs)
-    | Ir.Lam lambda ->
+    match value with
+    | Evaluation_ir.Atom a -> Atom a
+    | Evaluation_ir.Constant c -> Constant c
+    | Evaluation_ir.Primitive p -> Primitive p
+    | Evaluation_ir.Name n -> Name n
+    | Evaluation_ir.Tuple vs -> Tuple (List.map (of_ir value_env) vs)
+    | Evaluation_ir.Inject (s, vs) -> Inject (s, List.map (of_ir value_env) vs)
+    | Evaluation_ir.Lam lambda ->
       Closure { lambda; value_env }
-    | Ir.Variable (v, _) ->
+    | Evaluation_ir.Variable v ->
       begin
       match VarMap.find_opt v value_env with
         | Some irv -> irv
@@ -49,30 +48,22 @@ module RuntimeValue = struct
 
   let rec to_ir runtime_value =
     match runtime_value with
-    | Atom a ->
-      WithIrMetadata.make (Ir.Atom a)
-    | Constant c ->
-      WithIrMetadata.make (Ir.Constant c)
-    | Primitive p ->
-      WithIrMetadata.make (Ir.Primitive p)
-    | Name n ->
-      WithIrMetadata.make (Ir.Name n)
-    | Tuple vs ->
-      WithIrMetadata.make (Ir.Tuple (List.map to_ir vs))
-    | Inject (s, vs) ->
-      WithIrMetadata.make (Ir.Inject (s, List.map to_ir vs))
-    | Closure { lambda; value_env = _ } ->
-      WithIrMetadata.make (Ir.Lam lambda)
-    | Declaration var ->
-      WithIrMetadata.make (Ir.Variable (var, None))
+    | Atom a -> Evaluation_ir.Atom a
+    | Constant c -> Evaluation_ir.Constant c
+    | Primitive p -> Evaluation_ir.Primitive p
+    | Name n -> Evaluation_ir.Name n
+    | Tuple vs -> Evaluation_ir.Tuple (List.map to_ir vs)
+    | Inject (s, vs) -> Evaluation_ir.Inject (s, List.map to_ir vs)
+    | Closure { lambda; value_env = _ } -> Evaluation_ir.Lam lambda
+    | Declaration var -> Evaluation_ir.Variable var
 
   let pp ppf runtime_value =
-    Ir.pp_value ppf (to_ir runtime_value)
+    Evaluation_ir.pp_value ppf (to_ir runtime_value)
 end
 
 type value_env = RuntimeValue.value_env
 
-type runtime_message = (Ir.message_tag * RuntimeValue.t list)
+type runtime_message = (message_tag * RuntimeValue.t list)
 
 (* Only closures and tuples need to be reference counted (data constructors
    are not yet representable as runtime values). *)
@@ -90,7 +81,7 @@ let rec find_empty_guard guards =
   | [] -> runtime_error "No messages available but no 'empty' guard."
   | guard :: rest ->
     begin
-      match WithIrMetadata.node guard with
+      match guard with
       | Empty (mailbox_binder, cont) -> (mailbox_binder, cont)
       | _ -> find_empty_guard rest
     end
@@ -127,7 +118,7 @@ let rec find_receive_guard tag guards =
       (Format.asprintf "No receive guard available for message tag %s. This should not happen." tag)
   | guard :: rest ->
     begin
-      match WithIrMetadata.node guard with
+      match guard with
       | Receive recv_guard when recv_guard.tag = tag -> recv_guard
       | _ -> find_receive_guard tag rest 
     end

--- a/lib/interp/runtime_common.ml
+++ b/lib/interp/runtime_common.ml
@@ -19,10 +19,13 @@ module RuntimeValue = struct
     | Primitive of primitive_name
     | Name of RuntimeName.t
     | Tuple of t list
+    | Inject of (string * t list)
     | Closure of {
         lambda: lambda;
         value_env: value_env;
       }
+    (* An unresolved reference to a top-level declaration. *)
+    | Declaration of Var.t
 
   let rec of_ir value_env value =
     match WithIrMetadata.node value with
@@ -32,6 +35,7 @@ module RuntimeValue = struct
     | Ir.Primitive p -> Primitive p
     | Ir.Name n -> Name n
     | Ir.Tuple vs -> Tuple (List.map (of_ir value_env) vs)
+    | Ir.Inject (s, vs) -> Inject (s, List.map (of_ir value_env) vs)
     | Ir.Lam lambda ->
       Closure { lambda; value_env }
     | Ir.Variable (v, _) ->
@@ -42,8 +46,6 @@ module RuntimeValue = struct
           runtime_error
             (Format.asprintf "Unbound variable during IR conversion: %a" Var.pp v)
       end
-    | Ir.Inject (_s, _vs) ->
-        runtime_error "Evaluating user-defined datatypes not yet supported"
 
   let rec to_ir runtime_value =
     match runtime_value with
@@ -57,8 +59,12 @@ module RuntimeValue = struct
       WithIrMetadata.make (Ir.Name n)
     | Tuple vs ->
       WithIrMetadata.make (Ir.Tuple (List.map to_ir vs))
+    | Inject (s, vs) ->
+      WithIrMetadata.make (Ir.Inject (s, List.map to_ir vs))
     | Closure { lambda; value_env = _ } ->
       WithIrMetadata.make (Ir.Lam lambda)
+    | Declaration var ->
+      WithIrMetadata.make (Ir.Variable (var, None))
 
   let pp ppf runtime_value =
     Ir.pp_value ppf (to_ir runtime_value)
@@ -67,6 +73,14 @@ end
 type value_env = RuntimeValue.value_env
 
 type runtime_message = (Ir.message_tag * RuntimeValue.t list)
+
+(* Only closures and tuples need to be reference counted (data constructors
+   are not yet representable as runtime values). *)
+let should_ref_count =
+  let open RuntimeValue in
+  function
+    | Closure _ | Tuple _ | Inject _ -> true
+    | _ -> false
 
 
 let rec find_empty_guard guards =

--- a/lib/interp/runtime_common.ml
+++ b/lib/interp/runtime_common.ml
@@ -63,8 +63,6 @@ type value_env = RuntimeValue.value_env
 
 type runtime_message = (message_tag * RuntimeValue.t list)
 
-(* Only closures and tuples need to be reference counted (data constructors
-   are not yet representable as runtime values). *)
 let should_ref_count =
   let open RuntimeValue in
   function

--- a/lib/interp/runtime_common.ml
+++ b/lib/interp/runtime_common.ml
@@ -1,4 +1,5 @@
 open Common
+open Common_types
 open Evaluation_ir
 
 module VarMap = Map.Make(Var)
@@ -27,38 +28,35 @@ module RuntimeValue = struct
     (* An unresolved reference to a top-level declaration. *)
     | Declaration of Var.t
 
-  let rec of_ir value_env value =
+  let resolve_var value_env v =
+    match VarMap.find_opt v value_env with
+      | Some irv -> irv
+      | None ->
+        runtime_error
+          (Format.asprintf "Unbound variable during IR conversion: %a" Var.pp v)
+
+  let of_ir value_env value =
     match value with
     | Evaluation_ir.Atom a -> Atom a
     | Evaluation_ir.Constant c -> Constant c
     | Evaluation_ir.Primitive p -> Primitive p
     | Evaluation_ir.Name n -> Name n
-    | Evaluation_ir.Tuple vs -> Tuple (List.map (of_ir value_env) vs)
-    | Evaluation_ir.Inject (s, vs) -> Inject (s, List.map (of_ir value_env) vs)
+    | Evaluation_ir.Tuple vs -> Tuple (List.map (resolve_var value_env) vs)
+    | Evaluation_ir.Inject (s, vs) -> Inject (s, List.map (resolve_var value_env) vs)
     | Evaluation_ir.Lam lambda ->
       Closure { lambda; value_env }
-    | Evaluation_ir.Variable v ->
-      begin
-      match VarMap.find_opt v value_env with
-        | Some irv -> irv
-        | None ->
-          runtime_error
-            (Format.asprintf "Unbound variable during IR conversion: %a" Var.pp v)
-      end
+    | Evaluation_ir.Variable v -> resolve_var value_env v
 
-  let rec to_ir runtime_value =
+  let rec pp ppf runtime_value =
     match runtime_value with
-    | Atom a -> Evaluation_ir.Atom a
-    | Constant c -> Evaluation_ir.Constant c
-    | Primitive p -> Evaluation_ir.Primitive p
-    | Name n -> Evaluation_ir.Name n
-    | Tuple vs -> Evaluation_ir.Tuple (List.map to_ir vs)
-    | Inject (s, vs) -> Evaluation_ir.Inject (s, List.map to_ir vs)
-    | Closure { lambda; value_env = _ } -> Evaluation_ir.Lam lambda
-    | Declaration var -> Evaluation_ir.Variable var
-
-  let pp ppf runtime_value =
-    Evaluation_ir.pp_value ppf (to_ir runtime_value)
+    | Atom a -> Format.pp_print_string ppf (":" ^ a)
+    | Constant c -> Constant.pp ppf c
+    | Primitive p -> Format.pp_print_string ppf p
+    | Name n -> RuntimeName.pp ppf n
+    | Tuple ts -> Format.fprintf ppf "%a" (Util.Utility.pp_print_comma_list pp) ts
+    | Inject (s, ts) -> Format.fprintf ppf "%s(%a)" s (Util.Utility.pp_print_comma_list pp) ts
+    | Closure { lambda; _ } -> Format.fprintf ppf "fun(%a) { ... }" (Util.Utility.pp_print_comma_list Binder.pp) lambda.parameters
+    | Declaration var -> Var.pp ppf var
 end
 
 type value_env = RuntimeValue.value_env

--- a/lib/interp/runtime_common.ml
+++ b/lib/interp/runtime_common.ml
@@ -31,7 +31,6 @@ module RuntimeValue = struct
         lambda: lambda;
         value_env: value_env;
       }
-    (* An unresolved reference to a top-level declaration. *)
     | Declaration of Var.t
 
   let resolve_var value_env v =
@@ -79,6 +78,8 @@ let rec runtime_names_in_runtime_value value =
   | Inject (_, vs) -> List.concat_map runtime_names_in_runtime_value vs
   | Atom _ | Constant _ | Primitive _ | Closure _ | Declaration _ -> []
 
+(* When returning from a frame, any value for which this predicate returns true
+    will be tracked & RCed by the runtime *)
 let should_ref_count =
   let open RuntimeValue in
   function

--- a/lib/typecheck/gen_constraints.ml
+++ b/lib/typecheck/gen_constraints.ml
@@ -412,8 +412,6 @@ and synthesise_comp :
                For the purposes of the spawning thread, we treat all inferred
                usages as Usable. *)
             Type.unit_type, Ty_env.make_usable env, constrs
-        | Drop _ | Dup _ ->
-            raise (Errors.internal_error "gen_constraints.ml" "Drop and Dup should only be inserted after typechecking")
         | _ -> Gripers.cannot_synthesise e [pos]
 
 (* Check --> Synth switch. Ensures synthesised type is subtype of checked type. *)
@@ -721,8 +719,6 @@ and check_comp : IEnv.t -> Ty_env.t -> Ir.comp -> Type.t -> Ty_env.t * Constrain
                      pat_constrs]
             in
             (env, constrs)
-        | Drop _ | Dup _ ->
-            raise (Errors.internal_error "gen_constraints.ml" "Drop and Dup should only be inserted after typechecking")
         | _ ->
             (* If we don't have a checking rule, it might be possible to
                synthesise and then check the result. *)

--- a/lib/typecheck/pretypecheck.ml
+++ b/lib/typecheck/pretypecheck.ml
@@ -501,8 +501,6 @@ and synthesise_comp ienv env comp =
                         g :: gs, g_ty
             in
             wrap (Guard { target; pattern; guards; iname = Some iname }), g_ty
-        | Drop _ | Dup _ ->
-            raise (Errors.internal_error "pretypecheck.ml" "Drop and Dup should only be inserted after typechecking")
 and check_comp ienv env comp ty  =
     let pos = WithIrMetadata.pos comp in
     let fvs = WithIrMetadata.fvs comp in

--- a/test/examples/savina/kfork.pat
+++ b/test/examples/savina/kfork.pat
@@ -15,7 +15,7 @@ def actor(self: ActorMb?): Unit {
     free ->
       print("freed")
     receive Packet() from self ->
-      let dummy = fact(rand(100000)) in
+      let dummy = fact(rand(10)) in
       actor(self)
   }
 }
@@ -55,7 +55,8 @@ def main(): Unit {
   spawn { actor(actorMb3) };
 
   flood(100, actorMb1);
-  flood(1000, actorMb1)
+  flood(100, actorMb2);
+  flood(100, actorMb3)
 }
 
 main()

--- a/test/examples/savina/kfork.pat
+++ b/test/examples/savina/kfork.pat
@@ -13,7 +13,7 @@ interface ActorMb {
 def actor(self: ActorMb?): Unit {
   guard self: Packet* {
     free ->
-      ()
+      print("freed")
     receive Packet() from self ->
       let dummy = fact(rand(100000)) in
       actor(self)
@@ -32,6 +32,7 @@ def fact(n: Int): Int {
 
 ## Sends the given number of messages to the specified actor mailbox.
 def flood(numMessages: Int, actorMb: ActorMb!): Unit {
+  print(intToString(numMessages));
   if (numMessages <= 0) {
     ()
   }
@@ -54,8 +55,7 @@ def main(): Unit {
   spawn { actor(actorMb3) };
 
   flood(100, actorMb1);
-  flood(1000, actorMb1);
-  flood(10000, actorMb1)
+  flood(1000, actorMb1)
 }
 
 main()

--- a/test/pat-tests/data-4.pat
+++ b/test/pat-tests/data-4.pat
@@ -22,7 +22,7 @@ def choose(flag: Bool, mb: Mb![R]): Either(Mb![R], Int) {
 
 def main(): Unit {
     let mb = new [Mb] in
-    spawn { guard mb : Done { free -> () receive Done() from mb -> free(mb) } };
+    spawn { guard mb : Done { free -> () receive Done() from mb -> (print("freed"); free(mb)) } };
 
     ## choose(true, mb) wraps mb in Left; case below sends Done message
     let result = (choose(true, mb) : Either(Mb![R], Int)) in

--- a/test/pat-tests/heap-arg-ctor.pat
+++ b/test/pat-tests/heap-arg-ctor.pat
@@ -1,0 +1,32 @@
+### Regression test: a heap value built *inline as a call argument*.
+###
+### Constructors, tuples and lambdas are reference-counted via a tracked
+### allocation, which previously only happened for let-bound values. An argument
+### built at the call site (rather than let-bound first) reached the callee as an
+### untracked value, so destructuring it failed with
+### "Non runtime-name in runtime_name_of_var".
+###
+### Nested on purpose: the mailbox sits inside a constructor inside a tuple.
+
+data Either a b = Left a | Right b
+
+interface Mb {
+    Done()
+}
+
+def wrap(y: Either(Mb![R], Int)): Unit {
+    let t = (y, 1) in
+    let (m, n) = t in
+    case m : Either(Mb![R], Int) of {
+        Left(mb)  -> mb ! Done()
+      | Right(r) -> ()
+    }
+}
+
+def main(): Unit {
+    let mb = new [Mb] in
+    spawn { guard mb : Done { free -> () receive Done() from mb -> (print("freed"); free(mb)) } };
+    wrap(Left(mb))
+}
+
+main()

--- a/test/pat-tests/heap-arg-lambda.pat
+++ b/test/pat-tests/heap-arg-lambda.pat
@@ -1,0 +1,15 @@
+### Regression test: a lambda passed *inline as a call argument*, then invoked.
+###
+### Closures are reference-counted like other heap values. A lambda built at the
+### call site arrived in the callee as a raw closure rather than a tracked name,
+### so applying it failed with "Function position must be a declaration, lambda,
+### or primitive".
+
+def apply(f: (Int) -> Int, v: Int): Int {
+    f(v)
+}
+
+def main(): Unit {
+    print(intToString(apply(fun (x: Int): Int { x + 1 }, 5)))
+}
+main()

--- a/test/pat-tests/heap-payload-ctor.pat
+++ b/test/pat-tests/heap-payload-ctor.pat
@@ -1,0 +1,22 @@
+### Regression test: a heap value built *inline as a message payload*.
+###
+### Same underlying issue as heap-arg-ctor.pat, but on the send path: payloads
+### are stored in the mailbox and rebound at the receive, so a constructor built
+### directly in the send reached the receiver untracked and could not be cased.
+
+data Box a = MkBox a
+
+interface Mb { Msg(Box(Int)) }
+
+def main(): Unit {
+    let mb = new[Mb] in
+    mb ! Msg(MkBox(42));
+    guard mb : Msg {
+        receive Msg(b) from mb ->
+            free(mb);
+            case b : Box(Int) of {
+                MkBox(n) -> print(intToString(n))
+            }
+    }
+}
+main()

--- a/test/pat-tests/spawn-dup-hoist.pat
+++ b/test/pat-tests/spawn-dup-hoist.pat
@@ -1,0 +1,40 @@
+### Regression test for reference counting across 'spawn'.
+###
+### The duplication that a spawned body needs from the enclosing scope must be
+### performed by the parent thread, before the child is created. Here the use of
+### 'mb' sits behind a let-binding, so a translation that only hoists a 'dup'
+### appearing at the very front of the body would leave it inside the child --
+### and the parent would consume its own reference with the send before the
+### child is ever scheduled.
+
+interface ActorMb {
+  Packet()
+}
+
+def actor(self: ActorMb?): Unit {
+  guard self: Packet* {
+    free ->
+      print("freed")
+    receive Packet() from self ->
+      actor(self)
+  }
+}
+
+## Burns enough interpreter steps that the spawned thread is descheduled before
+## it reaches the use of 'mb'.
+def burn(n: Int): Int {
+  if (n <= 0) {
+    0
+  }
+  else {
+    burn(n - 1)
+  }
+}
+
+def main(): Unit {
+  let mb = new [ActorMb] in
+  spawn { let d = burn(50) in actor(mb) };
+  mb ! Packet()
+}
+
+main()

--- a/test/pat-tests/tuple-counting.pat
+++ b/test/pat-tests/tuple-counting.pat
@@ -1,0 +1,24 @@
+### Regression test for reference counting of tuple *construction*.
+###
+### Building a tuple captures one reference per field, so a field mentioned twice
+### needs a dup for the second occurrence. A translation that emitted no dups for
+### tuple fields would under-count 'mb' here: the tuple holds two references but
+### only one was accounted for, so dropping it took the count below zero.
+###
+### Needs -q -j: aliasing 'mb' into both fields is only well-typed with
+### quasilinearity and disjointness checking relaxed.
+
+interface Test { }
+
+def ignore(x: (Test! * Test!)): Unit {
+    ()
+}
+
+def main(): Unit {
+    let mb = new[Test] in
+    spawn { ignore((mb, mb)) };
+    guard mb : 1 {
+        free -> print("freed")
+    }
+}
+main()

--- a/test/tests.json
+++ b/test/tests.json
@@ -693,6 +693,48 @@
                     "exit_code": 0,
                     "stdout": "Ignoring 1!\nIgnored 1!\nIgnoring 2!\nIgnored 2!\nFreed!\n",
                     "stderr": ""
+                },
+                {
+                    "name": "data-1",
+                    "filename": "pat-tests/data-1.pat",
+                    "exit_code": 0,
+                    "stdout": "42\n0\n",
+                    "stderr": ""
+                },
+                {
+                    "name": "data-2",
+                    "filename": "pat-tests/data-2.pat",
+                    "exit_code": 0,
+                    "stdout": "3\n",
+                    "stderr": ""
+                },
+                {
+                    "name": "data-3",
+                    "filename": "pat-tests/data-3.pat",
+                    "exit_code": 0,
+                    "stdout": "1\n",
+                    "stderr": ""
+                },
+                {
+                    "name": "data-4",
+                    "filename": "pat-tests/data-4.pat",
+                    "exit_code": 0,
+                    "stdout": "freed\n",
+                    "stderr": ""
+                },
+                {
+                    "name": "data-expr",
+                    "filename": "pat-tests/data-expr.pat",
+                    "exit_code": 0,
+                    "stdout": "20\n",
+                    "stderr": ""
+                },
+                {
+                    "name": "data-mixed",
+                    "filename": "pat-tests/data-mixed.pat",
+                    "exit_code": 0,
+                    "stdout": "6\nHello!\n",
+                    "stderr": ""
                 }
             ]
         },

--- a/test/tests.json
+++ b/test/tests.json
@@ -596,30 +596,26 @@
                     "filename": "pat-tests/list-1.pat",
                     "exit_code": 0,
                     "stdout": "5\n",
-                    "stderr": "",
-                    "ignore": true
+                    "stderr": ""
                 },
                 {
                     "name": "list-2",
                     "filename": "pat-tests/list-2.pat",
                     "exit_code": 0,
                     "stdout": "3\n",
-                    "stderr": "",
-                    "ignore": true
+                    "stderr": ""
                 },
                 {
                     "name": "list-mb",
                     "filename": "pat-tests/list-mb.pat",
                     "exit_code": 0,
                     "stdout": "done\n",
-                    "stderr": "",
-                    "ignore": true
+                    "stderr": ""
                 },
                 {
                     "name": "Tree traversal",
                     "filename": "pat-tests/traversal.pat",
-                    "exit_code": 0,
-                    "ignore": true
+                    "exit_code": 0
                 },
                 {
                     "name": "mb-function-return",
@@ -668,16 +664,14 @@
                     "filename": "pat-tests/sum-1.pat",
                     "exit_code": 0,
                     "stdout": "5\n",
-                    "stderr": "",
-                    "ignore": true
+                    "stderr": ""
                 },
                 {
                     "name": "sum-2",
                     "filename": "pat-tests/sum-2.pat",
                     "exit_code": 0,
                     "stdout": "5\n",
-                    "stderr": "",
-                    "ignore": true
+                    "stderr": ""
                 },
                 {
                     "name": "unr-mb-fun",

--- a/test/tests.json
+++ b/test/tests.json
@@ -660,6 +660,13 @@
                     "stderr": ""
                 },
                 {
+                    "name": "spawn-dup-hoist",
+                    "filename": "pat-tests/spawn-dup-hoist.pat",
+                    "exit_code": 0,
+                    "stdout": "freed\n",
+                    "stderr": ""
+                },
+                {
                     "name": "sum-1",
                     "filename": "pat-tests/sum-1.pat",
                     "exit_code": 0,

--- a/test/tests.json
+++ b/test/tests.json
@@ -735,6 +735,38 @@
                     "exit_code": 0,
                     "stdout": "6\nHello!\n",
                     "stderr": ""
+                },
+                {
+                    "name": "tuple-counting",
+                    "filename": "pat-tests/tuple-counting.pat",
+                    "exit_code": 0,
+                    "stdout": "freed\n",
+                    "stderr": "",
+                    "args": [
+                        "-q",
+                        "-j"
+                    ]
+                },
+                {
+                    "name": "heap-arg-ctor",
+                    "filename": "pat-tests/heap-arg-ctor.pat",
+                    "exit_code": 0,
+                    "stdout": "freed\n",
+                    "stderr": ""
+                },
+                {
+                    "name": "heap-payload-ctor",
+                    "filename": "pat-tests/heap-payload-ctor.pat",
+                    "exit_code": 0,
+                    "stdout": "42\n",
+                    "stderr": ""
+                },
+                {
+                    "name": "heap-arg-lambda",
+                    "filename": "pat-tests/heap-arg-lambda.pat",
+                    "exit_code": 0,
+                    "stdout": "6\n",
+                    "stderr": ""
                 }
             ]
         },


### PR DESCRIPTION
This PR allows datatypes to be evaluated. This is nontrivial as we need to be careful about reference counting (a la Perceus).

Precisely:

  * Introduce an evaluation IR (`evaluation_ir.ml`) that strips away unnecessary data like types, line numbers, and FVs, which reduces a lot of complexity. Also much more amenable to reference counting: for example case-scrutinee must be a variable, same with constructor contents. 
  * Evaluation IR is created as a result of reference counting. Requires a let-insertion pass.
  * Generalise runtime to track arbitrary values rather than just closures
  * Change CEK evaluator to work on evaluation IR rather than Common.ir
  * Fix various bugs found along the way.